### PR TITLE
[Feat] FeedView 상단 컴포넌트 생성

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0487509A29B83DBD006836D1 /* FeedFooterView.swift */; };
 		048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048750A229B8A2D4006836D1 /* AddMealView.swift */; };
+		048750A529B8ABA1006836D1 /* FeedTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048750A429B8ABA1006836D1 /* FeedTitleView.swift */; };
 		04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1188F29B74BF40073EDB7 /* FeedView.swift */; };
 		04C1189329B74D6C0073EDB7 /* FeedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1189229B74D6C0073EDB7 /* FeedHeaderView.swift */; };
 		04C1189529B74DD60073EDB7 /* TempFeedHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1189429B74DD60073EDB7 /* TempFeedHeader.swift */; };
@@ -36,6 +37,7 @@
 /* Begin PBXFileReference section */
 		0487509A29B83DBD006836D1 /* FeedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedFooterView.swift; sourceTree = "<group>"; };
 		048750A229B8A2D4006836D1 /* AddMealView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddMealView.swift; sourceTree = "<group>"; };
+		048750A429B8ABA1006836D1 /* FeedTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTitleView.swift; sourceTree = "<group>"; };
 		04C1188F29B74BF40073EDB7 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		04C1189229B74D6C0073EDB7 /* FeedHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedHeaderView.swift; sourceTree = "<group>"; };
 		04C1189429B74DD60073EDB7 /* TempFeedHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFeedHeader.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				04C1189229B74D6C0073EDB7 /* FeedHeaderView.swift */,
 				0487509A29B83DBD006836D1 /* FeedFooterView.swift */,
 				048750A229B8A2D4006836D1 /* AddMealView.swift */,
+				048750A429B8ABA1006836D1 /* FeedTitleView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */,
 				7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */,
 				7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */,
+				048750A529B8ABA1006836D1 /* FeedTitleView.swift in Sources */,
 				7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */,
 				7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */,
 			);

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1188F29B74BF40073EDB7 /* FeedView.swift */; };
 		04C1189329B74D6C0073EDB7 /* FeedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1189229B74D6C0073EDB7 /* FeedHeaderView.swift */; };
 		04C1189529B74DD60073EDB7 /* TempFeedHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C1189429B74DD60073EDB7 /* TempFeedHeader.swift */; };
+		04E9931929B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E9931829B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift */; };
 		630BA6C029AF57BE00019F2E /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6BF29AF57BE00019F2E /* Camera.swift */; };
 		630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6C129AF57F700019F2E /* CameraViewModel.swift */; };
 		6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366BA1D29B613C1004374BE /* CameraPreviewView.swift */; };
@@ -41,6 +42,7 @@
 		04C1188F29B74BF40073EDB7 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		04C1189229B74D6C0073EDB7 /* FeedHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedHeaderView.swift; sourceTree = "<group>"; };
 		04C1189429B74DD60073EDB7 /* TempFeedHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFeedHeader.swift; sourceTree = "<group>"; };
+		04E9931829B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePhotoButtonView.swift; sourceTree = "<group>"; };
 		630BA6BF29AF57BE00019F2E /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		630BA6C129AF57F700019F2E /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
 		6366BA1D29B613C1004374BE /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				0487509A29B83DBD006836D1 /* FeedFooterView.swift */,
 				048750A229B8A2D4006836D1 /* AddMealView.swift */,
 				048750A429B8ABA1006836D1 /* FeedTitleView.swift */,
+				04E9931829B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */,
 				7E4B1AA129A8E58900DDC65B /* TempComment.swift in Sources */,
+				04E9931929B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift in Sources */,
 				0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */,
 				7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */,
 				7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */,

--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct AddMealView: View {
-    @State var commentInput: String = ""
     
     let paddingLR: CGFloat = 16
     
@@ -17,25 +16,22 @@ struct AddMealView: View {
             Button(action: {
                 // TODO: 끼니 추가 액션
             }, label: {
+                RoundedRectangle(cornerRadius: 20)
+                    .frame(height: 50)
+                    .foregroundColor(.white)
+                    .shadow(color: .black.opacity(0.10), radius: 20, x: 4, y: 4)
+                    .padding([.leading, .trailing], paddingLR)
+            })
+            HStack(spacing: 12) {
                 Image(systemName: "camera")
                     .tint(.black)
                     .font(.body)
-            
-            RoundedRectangle(cornerRadius: 20)
-                .frame(height: 50)
-                .foregroundColor(.white)
-                .shadow(color: .black.opacity(0.10), radius: 20, x: 4, y: 4)
-                .padding([.leading, .trailing], paddingLR)
-            })
-            HStack {
-                TextField("What are you eating now?", text: $commentInput)
-                    .font(.body)
+                Text("What are you eating now?")
+                    .font(.subheadline)
                 Spacer()
-                
             }
-            .padding([.leading, .trailing], 34)
+            .padding([.leading], 34)
         }
-        
     }
 }
 

--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -19,8 +19,7 @@ struct AddMealView: View {
                 RoundedRectangle(cornerRadius: 20)
                     .frame(height: 50)
                     .foregroundColor(.white)
-                    .shadow(color: .black.opacity(0.10), radius: 20, x: 4, y: 4)
-                    .padding([.leading, .trailing], paddingLR)
+                    .shadow(color: .black.opacity(0.10), radius: 10, x: 4, y: 4)
             })
             HStack(spacing: 12) {
                 Image(systemName: "camera")

--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -29,7 +29,7 @@ struct AddMealView: View {
                     .font(.subheadline)
                 Spacer()
             }
-            .padding([.leading], 34)
+            .padding([.leading], 22)
         }
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -15,7 +15,7 @@ struct FeedHeaderView: View {
     
     var body: some View {
         VStack {
-            HStack(alignment: .top) {
+            HStack(alignment: .center, spacing: 12) {
                 ZStack {
                     Rectangle()
                         .aspectRatio(contentMode: .fit)
@@ -35,15 +35,8 @@ struct FeedHeaderView: View {
                         .font(.subheadline)
                         .fontWeight(.semibold)
                     HStack(alignment: .bottom, spacing: 8) {
-                        Text(PostInfo.place)
+                        Text("\(PostInfo.place) • \(PostInfo.time)")
                             .font(.footnote)
-                            .foregroundColor(.gray)
-                        Text("·")
-                            .font(.footnote)
-                            .foregroundColor(.gray)
-                        Text(PostInfo.time)
-                            .font(.footnote)
-                            .foregroundColor(.gray)
                     }
                 }
                 .padding([.leading], 12)

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -39,8 +39,6 @@ struct FeedHeaderView: View {
                             .font(.footnote)
                     }
                 }
-                .padding([.leading], 12)
-                .padding([.top], 2)
                 
                 Spacer()
             }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
@@ -7,22 +7,33 @@
 
 import SwiftUI
 
-
 struct FeedTitleView: View {
+    var body: some View {
+        HStack(alignment: .center) {
+            Text("I ate It ")
+                .fontWeight(.semibold)
+            Image(systemName: "fork.knife")
+                .tint(.black)
+                .font(.body)
+        }
+    }
+}
+
+struct ProfilePhotoView: View {
     
     var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
     
     var body: some View {
         ZStack{
-            HStack(alignment: .center) {
-                Text("I ate It ")
-                    .fontWeight(.semibold)
-                Image(systemName: "fork.knife")
-                    .tint(.black)
-                    .font(.body)
-            }
-            HStack{
-                Spacer()
+//            HStack(alignment: .center) {
+//                Text("I ate It ")
+//                    .fontWeight(.semibold)
+//                Image(systemName: "fork.knife")
+//                    .tint(.black)
+//                    .font(.body)
+//            }
+//            HStack{
+//                Spacer()
                 Button {
                     //TODO: 프로필 내비게이션
                 } label: {
@@ -40,10 +51,10 @@ struct FeedTitleView: View {
                     .cornerRadius(14)
                     .padding([.top], 3)
                 }
-            }
-            .padding([.trailing], 16)
+//            }
+//            .padding([.trailing], 16)
         }
-        .padding([.top], 17)
-        .padding([.bottom], 24)
+//        .padding([.top], 17)
+//        .padding([.bottom], 24)
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
@@ -18,29 +18,3 @@ struct FeedTitleView: View {
         }
     }
 }
-
-struct ProfilePhotoView: View {
-    
-    var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
-    
-    var body: some View {
-        Button {
-            //TODO: 프로필 내비게이션
-        } label: {
-            ZStack{
-                Rectangle()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 28, height: 28)
-                Image(profileInfo.profileImage)
-                    .resizable()
-                    .scaledToFill()
-                    .layoutPriority(-1)
-                    .frame(width: 28, height: 28)
-            }
-            .clipped()
-            .cornerRadius(14)
-            .padding([.top], 3)
-        }
-    }
-    
-}

--- a/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
@@ -1,0 +1,49 @@
+//
+//  FeedTitleView.swift
+//  IAteIt
+//
+//  Created by Beone on 2023/03/08.
+//
+
+import SwiftUI
+
+
+struct FeedTitleView: View {
+    
+    var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
+    
+    var body: some View {
+        ZStack{
+            HStack(alignment: .center) {
+                Text("I ate It ")
+                    .fontWeight(.semibold)
+                Image(systemName: "fork.knife")
+                    .tint(.black)
+                    .font(.body)
+            }
+            HStack{
+                Spacer()
+                Button {
+                    //TODO: 프로필 내비게이션
+                } label: {
+                    ZStack{
+                        Rectangle()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 28, height: 28)
+                        Image(profileInfo.profileImage)
+                            .resizable()
+                            .scaledToFill()
+                            .layoutPriority(-1)
+                            .frame(width: 28, height: 28)
+                    }
+                    .clipped()
+                    .cornerRadius(14)
+                    .padding([.top], 3)
+                }
+            }
+            .padding([.trailing], 16)
+        }
+        .padding([.top], 17)
+        .padding([.bottom], 24)
+    }
+}

--- a/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedTitleView.swift
@@ -24,37 +24,23 @@ struct ProfilePhotoView: View {
     var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
     
     var body: some View {
-        ZStack{
-//            HStack(alignment: .center) {
-//                Text("I ate It ")
-//                    .fontWeight(.semibold)
-//                Image(systemName: "fork.knife")
-//                    .tint(.black)
-//                    .font(.body)
-//            }
-//            HStack{
-//                Spacer()
-                Button {
-                    //TODO: 프로필 내비게이션
-                } label: {
-                    ZStack{
-                        Rectangle()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 28, height: 28)
-                        Image(profileInfo.profileImage)
-                            .resizable()
-                            .scaledToFill()
-                            .layoutPriority(-1)
-                            .frame(width: 28, height: 28)
-                    }
-                    .clipped()
-                    .cornerRadius(14)
-                    .padding([.top], 3)
-                }
-//            }
-//            .padding([.trailing], 16)
+        Button {
+            //TODO: 프로필 내비게이션
+        } label: {
+            ZStack{
+                Rectangle()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 28, height: 28)
+                Image(profileInfo.profileImage)
+                    .resizable()
+                    .scaledToFill()
+                    .layoutPriority(-1)
+                    .frame(width: 28, height: 28)
+            }
+            .clipped()
+            .cornerRadius(14)
+            .padding([.top], 3)
         }
-//        .padding([.top], 17)
-//        .padding([.bottom], 24)
     }
+    
 }

--- a/IAteIt/IAteIt/View/Feed/Component/ProfilePhotoButtonView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/ProfilePhotoButtonView.swift
@@ -1,0 +1,33 @@
+//
+//  ProfilePhotoButtonView.swift
+//  IAteIt
+//
+//  Created by Beone on 2023/03/09.
+//
+
+import SwiftUI
+
+struct ProfilePhotoButtonView: View {
+    
+    var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
+    
+    var body: some View {
+        Button {
+            //TODO: 프로필 내비게이션
+        } label: {
+            ZStack{
+                Rectangle()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 28, height: 28)
+                Image(profileInfo.profileImage)
+                    .resizable()
+                    .scaledToFill()
+                    .layoutPriority(-1)
+                    .frame(width: 28, height: 28)
+            }
+            .clipped()
+            .cornerRadius(14)
+            .padding([.top], 3)
+        }
+    }
+}

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -12,28 +12,39 @@ struct FeedView: View {
     var tempPlateList = TempPlateData().list
     
     var body: some View {
-        ScrollView {
-            VStack{
-                FeedTitleView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
-                
-                AddMealView()
-                    .padding([.bottom], 24)
-                ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in
-                    FeedHeaderView(PostInfo: postInfo)
-                        .padding([.bottom], 8)
-                    TabView {
-                        ForEach(tempPlateList, id: \.self) { plate in
-                            PhotoCardView(plate: plate)
+        NavigationView{
+            ScrollView {
+                VStack{
+                    
+                    AddMealView()
+                        .padding([.top], 24)
+                        .padding([.bottom], 24)
+                        .padding([.leading, .trailing], 17)
+                    ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in
+                        FeedHeaderView(PostInfo: postInfo)
+                            .padding([.bottom], 8)
+                        TabView {
+                            ForEach(tempPlateList, id: \.self) { plate in
+                                PhotoCardView(plate: plate)
+                            }
                         }
+                        .frame(minHeight: 358)
+                        .tabViewStyle(.page)
+                        .padding([.bottom], 8)
+                        FeedFooterView()
+                            .padding([.bottom], 27)
                     }
-                    .frame(minHeight: 358)
-                    .tabViewStyle(.page)
-                    .padding([.bottom], 8)
-                    FeedFooterView()
-                        .padding([.bottom], 27)
                 }
             }
+            .navigationBarItems(leading:
+                    FeedTitleView()
+                    .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
+            )
+            .navigationBarItems(trailing:
+                                    ProfilePhotoView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
+            )
         }
+        
     }
 }
 

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -14,6 +14,8 @@ struct FeedView: View {
     var body: some View {
         ScrollView {
             VStack{
+                FeedTitleView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
+                
                 AddMealView()
                     .padding([.bottom], 24)
                 ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -19,7 +19,7 @@ struct FeedView: View {
                     AddMealView()
                         .padding([.top], 24)
                         .padding([.bottom], 24)
-                        .padding([.leading, .trailing], 17)
+                        .padding([.leading, .trailing], 16)
                     ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in
                         FeedHeaderView(PostInfo: postInfo)
                             .padding([.bottom], 8)
@@ -41,7 +41,7 @@ struct FeedView: View {
                     .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
             )
             .navigationBarItems(trailing:
-                                    ProfilePhotoView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
+                                    ProfilePhotoButtonView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
             )
         }
         

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -14,6 +14,8 @@ struct FeedView: View {
     var body: some View {
         ScrollView {
             VStack{
+                AddMealView()
+                    .padding([.bottom], 24)
                 ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in
                     FeedHeaderView(PostInfo: postInfo)
                         .padding([.bottom], 8)


### PR DESCRIPTION
## 관련 이슈들
- #11 

## 작업 내용
- 상단 타이틀의 컴포넌트를 생성
- 어플이름 텍스트, 프로필 내비버튼, 업로드버튼
- 프로필 내비 버튼 사진 데이터를 헤더에서 그냥 가져온거라 이를 포함해 피드뷰의 데이터 전체적 수정 필요

## 리뷰 노트
- 디자인에서, 업로드버튼이 텍스트필드같은 형상이라 UX에 영향을 줄 것 같습니다. 끼니 내 사진 추가 기능의 UI와 함께 생각해보면 좋을 것 같습니다

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2023-03-08 20 50 27" src="https://user-images.githubusercontent.com/70618615/223706049-2c85a233-5146-4d7d-838f-cfc695308fcb.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
