### PR TITLE
CameraView UI 수정, 카메라 촬영 저장기능 구현

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
-				DEVELOPMENT_TEAM = NH6966C938;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";
@@ -452,7 +452,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
-				DEVELOPMENT_TEAM = NH6966C938;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -419,10 +419,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = NH6966C938;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 권한 승인이 필요합니다.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이 앱은 사진을 촬영 후 저장합니다. 앨범 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -451,10 +452,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = NH6966C938;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 권한 승인이 필요합니다.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "이 앱은 사진을 촬영 후 저장합니다. 앨범 접근 권한을 허용해주세요.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/IAteIt/IAteIt/View/Upload/Camera.swift
+++ b/IAteIt/IAteIt/View/Upload/Camera.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import AVFoundation
 
-class Camera: ObservableObject {
+class Camera: NSObject, ObservableObject {
     var session = AVCaptureSession()
     var videoDeviceInput: AVCaptureDeviceInput!
     let output = AVCapturePhotoOutput()
@@ -57,4 +57,39 @@ class Camera: ObservableObject {
             print("Permession declined")
         }
     }
+    
+    func capturePhoto() {
+           // 사진 옵션 세팅
+           let photoSettings = AVCapturePhotoSettings()
+           
+           self.output.capturePhoto(with: photoSettings, delegate: self)
+           print("[Camera]: Photo's taken")
+       }
+    
+    func savePhoto(_ imageData: Data) {
+        guard let image = UIImage(data: imageData) else { return }
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        
+        // 사진 저장하기
+        print("[Camera]: Photo's saved")
+    }
+}
+    
+    extension Camera: AVCapturePhotoCaptureDelegate {
+        func photoOutput(_ output: AVCapturePhotoOutput, willBeginCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        }
+        
+        func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        }
+        
+        func photoOutput(_ output: AVCapturePhotoOutput, didCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+        }
+        
+        func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+            guard let imageData = photo.fileDataRepresentation() else { return }
+            self.savePhoto(imageData)
+            
+            print("[CameraModel]: Capture routine's done")
+        }
+    
 }

--- a/IAteIt/IAteIt/View/Upload/Camera.swift
+++ b/IAteIt/IAteIt/View/Upload/Camera.swift
@@ -13,7 +13,7 @@ class Camera: NSObject, ObservableObject {
     var videoDeviceInput: AVCaptureDeviceInput!
     let output = AVCapturePhotoOutput()
     
-    // 카메라 셋업 과정을 담당하는 함수, positio
+    // 카메라 셋업 과정을 담당하는 함수, position
     func setUpCamera() {
         if let device = AVCaptureDevice.default(.builtInWideAngleCamera,
                                                 for: .video, position: .back) {
@@ -30,13 +30,13 @@ class Camera: NSObject, ObservableObject {
                 }
                 session.startRunning() // 세션 시작
             } catch {
-                print(error) // 에러 프린트
+                print(error)
             }
         }
     }
     
     func requestAndCheckPermissions() {
-        // 카메라 권한 상태 확인
+
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .notDetermined:
             // 권한 요청
@@ -59,7 +59,7 @@ class Camera: NSObject, ObservableObject {
     }
     
     func capturePhoto() {
-        // 사진 옵션 세팅
+
         let photoSettings = AVCapturePhotoSettings()
         photoSettings.isHighResolutionPhotoEnabled = true
         photoSettings.photoQualityPrioritization = .quality

--- a/IAteIt/IAteIt/View/Upload/Camera.swift
+++ b/IAteIt/IAteIt/View/Upload/Camera.swift
@@ -68,18 +68,17 @@ class Camera: NSObject, ObservableObject {
         print("[Camera]: Photo's taken")
     }
     
-    func cropAndSavePhoto(_ imageData: Data) {
-        guard let image = UIImage(data: imageData) else { return }
+    func cropAndSavePhoto(_ imageData: Data) -> UIImage {
+        guard let image = UIImage(data: imageData) else { return UIImage() }
         let imageWidth = image.size.width
         let imageHeight = image.size.height
         let resize = imageHeight * 0.5
         let cropRect = CGRect(x: resize - imageWidth * 0.5, y: 0, width: imageWidth, height: imageWidth)
-        guard let croppedCGImage = image.cgImage?.cropping(to: cropRect) else { return }
+        guard let croppedCGImage = image.cgImage?.cropping(to: cropRect) else { return UIImage() }
         let croppedUIImage = UIImage(cgImage: croppedCGImage,
                                      scale: image.scale,
                                      orientation: image.imageOrientation)
-        UIImageWriteToSavedPhotosAlbum(croppedUIImage, nil, nil, nil)
-        print("이미지가 저장되었습니다.")
+        return croppedUIImage
     }
 }
 
@@ -95,8 +94,9 @@ extension Camera: AVCapturePhotoCaptureDelegate {
     
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
         guard let imageData = photo.fileDataRepresentation() else { return }
-        self.cropAndSavePhoto(imageData)
-        
+        let image = self.cropAndSavePhoto(imageData)
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        print("이미지가 저장되었습니다.")
         print("[CameraModel]: Capture routine's done")
     }
     

--- a/IAteIt/IAteIt/View/Upload/CameraPreviewView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraPreviewView.swift
@@ -27,7 +27,7 @@ struct CameraPreviewView: UIViewRepresentable {
         view.videoPreviewLayer.session = session
         view.backgroundColor = .black
         view.videoPreviewLayer.videoGravity = .resizeAspectFill
-        view.videoPreviewLayer.cornerRadius = 0
+        view.videoPreviewLayer.cornerRadius = 20
         view.videoPreviewLayer.connection?.videoOrientation = .portrait
         
         return view
@@ -36,4 +36,5 @@ struct CameraPreviewView: UIViewRepresentable {
     func updateUIView(_ uiView: VideoPreviewView, context: Context) {
         
     }
+
 }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -13,7 +13,7 @@ struct CameraView: View {
     
     var body: some View {
         ZStack {
-            viewModel.cameraPreview.ignoresSafeArea()
+            viewModel.cameraPreview
                 .onAppear {
                     viewModel.configure()
                 }
@@ -22,14 +22,14 @@ struct CameraView: View {
                 Spacer()
                 
                 Button(action: {viewModel.capturePhoto()}, label: {
-                    ZStack{
+//                    ZStack{
+//                        Circle()
+//                            .fill(.black)
+//                            .frame(width: 55.33, height: 55.33)
                         Circle()
-                            .fill(Color.white)
-                            .frame(width: 55.33, height: 55.33)
-                        Circle()
-                            .stroke(.white,lineWidth: 4)
+                            .stroke(.black,lineWidth: 4)
                             .frame(width: 72, height: 72)
-                    }
+//                    }
                     .padding()
                 })
             }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -22,14 +22,9 @@ struct CameraView: View {
                 Spacer()
                 
                 Button(action: {viewModel.capturePhoto()}, label: {
-//                    ZStack{
-//                        Circle()
-//                            .fill(.black)
-//                            .frame(width: 55.33, height: 55.33)
                         Circle()
                             .stroke(.black,lineWidth: 4)
                             .frame(width: 72, height: 72)
-//                    }
                     .padding()
                 })
             }

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -18,7 +18,7 @@ class CameraViewModel: ObservableObject {
         session = model.session
         
         let screenSize = UIScreen.main.bounds.size
-        let length = min(screenSize.width, screenSize.height)
+        let length: CGFloat = min(screenSize.width - 16, screenSize.height)
         cameraPreview = AnyView(CameraPreviewView(session: session)
             .frame(width: length, height: length))
     }

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -16,7 +16,11 @@ class CameraViewModel: ObservableObject {
     init() {
         model = Camera()
         session = model.session
-        cameraPreview = AnyView(CameraPreviewView(session: session))
+        
+        let screenSize = UIScreen.main.bounds.size
+        let length = min(screenSize.width, screenSize.height)
+        cameraPreview = AnyView(CameraPreviewView(session: session)
+            .frame(width: length, height: length))
     }
     
     func configure() {
@@ -24,6 +28,7 @@ class CameraViewModel: ObservableObject {
     }
     
     func capturePhoto() {
+        model.capturePhoto()
         print("[CameraViewModel]: Photo captured!")
     }
     


### PR DESCRIPTION
## 관련 이슈들
- #8 

## 작업 내용
- 카메라 프리뷰 ui 변경 적용
- 저장되는 사진 정방형으로 구현

## 리뷰 노트
- 카메라 프리뷰는 정방형으로 구현하기 쉬웠는데 저장되는 사진과 싱크가 안맞아 힘들었습니다. 
현재는 저장되는 사진과 프리뷰에서 보고 촬영한 사진이 똑같습니다!

## 스크린샷(UX의 경우 gif)
<img src="https://user-images.githubusercontent.com/103012086/226830102-b9cbb7e9-b374-4477-9208-424444cb2057.JPG" width="300">
<img src="https://user-images.githubusercontent.com/103012086/226830110-b35c7d77-5b82-4825-8678-99e3d72132f2.PNG" width="300">


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
