### PR TITLE
[Feat] #22 LoginView UI

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069DF29A7A7B400284CBD /* CommentView.swift */; };
 		7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */; };
 		7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */; };
+		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
 		7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28729A5228D0021B9FE /* IAteItApp.swift */; };
 		7EFFE28A29A5228D0021B9FE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28929A5228D0021B9FE /* ContentView.swift */; };
 		7EFFE28C29A5228F0021B9FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28B29A5228F0021B9FE /* Assets.xcassets */; };
@@ -61,6 +62,8 @@
 		7E6069DF29A7A7B400284CBD /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardView.swift; sourceTree = "<group>"; };
 		7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOnPhotoView.swift; sourceTree = "<group>"; };
+		7E9198A229CF56B400044815 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		7E9198A429CF591200044815 /* IAteIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IAteIt.entitlements; sourceTree = "<group>"; };
 		7EFFE28429A5228D0021B9FE /* IAteIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IAteIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EFFE28729A5228D0021B9FE /* IAteItApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAteItApp.swift; sourceTree = "<group>"; };
 		7EFFE28929A5228D0021B9FE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -111,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				7E6069CC29A5CADE00284CBD /* SignUpView.swift */,
+				7E9198A229CF56B400044815 /* LoginView.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -221,6 +225,7 @@
 		7EFFE28629A5228D0021B9FE /* IAteIt */ = {
 			isa = PBXGroup;
 			children = (
+				7E9198A429CF591200044815 /* IAteIt.entitlements */,
 				7E6069D929A5CB1E00284CBD /* Utility */,
 				7E6069C629A5CA6900284CBD /* View */,
 				7E6069D629A5CAFF00284CBD /* Model */,
@@ -322,7 +327,7 @@
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				DF883D4229B58F2C0029DC60 /* User.swift in Sources */,
-				7E6069CF29A5CAE500284CBD /* UploadView.swift in Sources */,
+				7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */,
 				630BA6C029AF57BE00019F2E /* Camera.swift in Sources */,
 				630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */,
 				7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */,
@@ -330,6 +335,7 @@
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */,
+				7E9198A329CF56B400044815 /* LoginView.swift in Sources */,
 				7E4B1AA129A8E58900DDC65B /* TempComment.swift in Sources */,
 				04E9931929B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift in Sources */,
 				0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */,
@@ -463,6 +469,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = IAteIt/IAteIt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -497,6 +504,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = IAteIt/IAteIt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/IAteIt/IAteIt/IAteIt.entitlements
+++ b/IAteIt/IAteIt/IAteIt.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -38,10 +38,14 @@ struct LoginView: View {
                 )
                 .padding([.bottom], 32)
             
-            Text("I'll sign in next time.")
-                .font(.body)
-                .foregroundColor(.gray)
-                .underline()
+            Button(action: {
+                // TODO: 액션 추가
+            }, label: {
+                Text("I'll sign in next time.")
+                    .font(.body)
+                    .foregroundColor(.gray)
+                    .underline()
+            })
         }
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -30,9 +30,12 @@ struct LoginView: View {
                       print("Authorisation failed: \(error.localizedDescription)")
                   }
                 }
-                .signInWithAppleButtonStyle(.whiteOutline)
+                .signInWithAppleButtonStyle(.white)
                 .frame(width: 268, height: 50, alignment: .center)
-                .cornerRadius(25)
+                .overlay(
+                        RoundedRectangle(cornerRadius: 25)
+                            .stroke(.black, lineWidth: 1)
+                )
                 .padding([.bottom], 32)
             
             Text("I'll sign in next time.")

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -1,0 +1,50 @@
+//
+//  LoginView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/03/26.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct LoginView: View {
+    var body: some View {
+        VStack {
+            Text("Sign in required!")
+                .font(.title)
+                .fontWeight(.bold)
+                .padding([.bottom], 26)
+            Text("Please sign in\nto share what you eat in a day.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding([.bottom], 44)
+            
+            SignInWithAppleButton(.signIn) { request in
+                  request.requestedScopes = [.fullName, .email]
+                } onCompletion: { result in
+                  switch result {
+                    case .success(let authResults):
+                      print("Authorisation successful \(authResults)")
+                    case .failure(let error):
+                      print("Authorisation failed: \(error.localizedDescription)")
+                  }
+                }
+                .signInWithAppleButtonStyle(.whiteOutline)
+                .frame(width: 268, height: 50, alignment: .center)
+                .cornerRadius(25)
+                .padding([.bottom], 32)
+            
+            Text("I'll sign in next time.")
+                .font(.body)
+                .foregroundColor(.gray)
+                .underline()
+        }
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}


### PR DESCRIPTION
## 관련 이슈들
- #22 

## 작업 내용
- SignUpView 진입 전 애플로그인을 하는 뷰 UI를 작업했습니다. 
- capabilities에 Sign in with Apple을 추가하고 LoginView UI를 그렸습니다.

## 리뷰 노트
- 이전 회의 시 개발 편의를 위해.. 최초 앱 설치 시 로그인/회원가입을 먼저 해야 앱을 이용할 수 있도록 논의했어서 "I'll sign in next time" 버튼은 그려놓긴 했는데 일단 없어도 될 것 같긴 합니다..

## 스크린샷(UX의 경우 gif)
<img width="300" alt="Screenshot 2023-03-27 at 2 48 17 AM" src="https://user-images.githubusercontent.com/103012157/227794338-98e4ee85-e1a0-4a63-a497-dc2233ed1f10.png">

## Reference
- [Sign in with Apple 버튼](https://velog.io/@ezenjun/SwiftUI-SignInWithAppleButton애플로그인-swift-5.0-XCode-14.2)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
