### PR TITLE
[Feat] #14 FeedView, MealDetailView UI 업데이트 및 데이터모델 반영

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366BA1D29B613C1004374BE /* CameraPreviewView.swift */; };
 		7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */; };
 		7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719329A90449005A7B56 /* TempPlate.swift */; };
+		7E42C95729DC112B00ABE32D /* MealDetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */; };
 		7E4B1AA129A8E58900DDC65B /* TempComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4B1AA029A8E58900DDC65B /* TempComment.swift */; };
 		7E6069CD29A5CADE00284CBD /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069CC29A5CADE00284CBD /* SignUpView.swift */; };
 		7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069CE29A5CAE500284CBD /* CameraView.swift */; };
@@ -34,13 +35,13 @@
 		7EFFE28A29A5228D0021B9FE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28929A5228D0021B9FE /* ContentView.swift */; };
 		7EFFE28C29A5228F0021B9FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28B29A5228F0021B9FE /* Assets.xcassets */; };
 		7EFFE28F29A5228F0021B9FE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28E29A5228F0021B9FE /* Preview Assets.xcassets */; };
+		8C73F00329BDD010007D1A1E /* DailyMealCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */; };
+		8C73F00529BDDAE6007D1A1E /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */; };
 		DF22139B29BB2843000134FC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DF22139A29BB2843000134FC /* GoogleService-Info.plist */; };
 		DF22139E29BB293C000134FC /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = DF22139D29BB293C000134FC /* FirebaseFirestore */; };
 		DF2213A029BB293C000134FC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = DF22139F29BB293C000134FC /* FirebaseStorage */; };
 		DF2213A229BB2ADC000134FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A129BB2ADC000134FC /* AppDelegate.swift */; };
 		DF2213A529BB324F000134FC /* FirebaseConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A429BB324F000134FC /* FirebaseConnector.swift */; };
-		8C73F00329BDD010007D1A1E /* DailyMealCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */; };
-		8C73F00529BDDAE6007D1A1E /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */; };
 		DF883D4229B58F2C0029DC60 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4129B58F2C0029DC60 /* User.swift */; };
 		DF883D4629B58F3D0029DC60 /* Plate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4529B58F3D0029DC60 /* Plate.swift */; };
 		DF883D4829B58F430029DC60 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4729B58F430029DC60 /* Comment.swift */; };
@@ -60,6 +61,7 @@
 		6366BA1D29B613C1004374BE /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
 		7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentBarView.swift; sourceTree = "<group>"; };
 		7E1F719329A90449005A7B56 /* TempPlate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempPlate.swift; sourceTree = "<group>"; };
+		7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealDetailTopView.swift; sourceTree = "<group>"; };
 		7E4B1AA029A8E58900DDC65B /* TempComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempComment.swift; sourceTree = "<group>"; };
 		7E6069CC29A5CADE00284CBD /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		7E6069CE29A5CAE500284CBD /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
@@ -77,11 +79,11 @@
 		7EFFE28929A5228D0021B9FE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7EFFE28B29A5228F0021B9FE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7EFFE28E29A5228F0021B9FE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMealCellView.swift; sourceTree = "<group>"; };
+		8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		DF22139A29BB2843000134FC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		DF2213A129BB2ADC000134FC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DF2213A429BB324F000134FC /* FirebaseConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseConnector.swift; sourceTree = "<group>"; };
-		8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMealCellView.swift; sourceTree = "<group>"; };
-		8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		DF883D4129B58F2C0029DC60 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DF883D4529B58F3D0029DC60 /* Plate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plate.swift; sourceTree = "<group>"; };
 		DF883D4729B58F430029DC60 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */,
 				7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */,
 				7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */,
+				7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				7E9198A329CF56B400044815 /* LoginView.swift in Sources */,
 				DF2213A229BB2ADC000134FC /* AppDelegate.swift in Sources */,
 				7E4B1AA129A8E58900DDC65B /* TempComment.swift in Sources */,
+				7E42C95729DC112B00ABE32D /* MealDetailTopView.swift in Sources */,
 				04E9931929B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift in Sources */,
 				0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */,
 				7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */,

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366BA1D29B613C1004374BE /* CameraPreviewView.swift */; };
 		7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */; };
 		7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719329A90449005A7B56 /* TempPlate.swift */; };
+		7E2B2DAD29DE9304009EC0ED /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B2DAC29DE9304009EC0ED /* Constants.swift */; };
 		7E42C95729DC112B00ABE32D /* MealDetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */; };
 		7E4B1AA129A8E58900DDC65B /* TempComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4B1AA029A8E58900DDC65B /* TempComment.swift */; };
 		7E6069CD29A5CADE00284CBD /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069CC29A5CADE00284CBD /* SignUpView.swift */; };
@@ -61,6 +62,7 @@
 		6366BA1D29B613C1004374BE /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
 		7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentBarView.swift; sourceTree = "<group>"; };
 		7E1F719329A90449005A7B56 /* TempPlate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempPlate.swift; sourceTree = "<group>"; };
+		7E2B2DAC29DE9304009EC0ED /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealDetailTopView.swift; sourceTree = "<group>"; };
 		7E4B1AA029A8E58900DDC65B /* TempComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempComment.swift; sourceTree = "<group>"; };
 		7E6069CC29A5CADE00284CBD /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				7E6069DA29A5CB2800284CBD /* Extension */,
+				7E2B2DAC29DE9304009EC0ED /* Constants.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7E6069D329A5CAF300284CBD /* MealDetailView.swift in Sources */,
+				7E2B2DAD29DE9304009EC0ED /* Constants.swift in Sources */,
 				DF883D4629B58F3D0029DC60 /* Plate.swift in Sources */,
 				7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */,
 				6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */,

--- a/IAteIt/IAteIt/Model/Comment.swift
+++ b/IAteIt/IAteIt/Model/Comment.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Comment: Identifiable, Codable {
+struct Comment: Identifiable, Codable, Hashable {
     let id: String
     let userId: String
     let mealId: String
@@ -20,7 +20,8 @@ extension Comment {
     static let comments: [Comment] = [
         Comment(id: UUID().uuidString, userId: "user1", mealId: "meal1", comment: "This is great", uploadDate: Date()),
         Comment(id: UUID().uuidString, userId: "user1", mealId: "meal2", comment: "This is comment From rain", uploadDate: Date()),
-        Comment(id: UUID().uuidString, userId: "user2", mealId: "meal2", comment: "This is awful", uploadDate: Date())
+        Comment(id: UUID().uuidString, userId: "user2", mealId: "meal2", comment: "This is awful", uploadDate: Date()),
+        Comment(id: UUID().uuidString, userId: "user1", mealId: "meal3", comment: "무플방지", uploadDate: Date()),
+        Comment(id: UUID().uuidString, userId: "user2", mealId: "meal3", comment: "두번째 코멘트 테스트", uploadDate: Date())
     ]
-    
 }

--- a/IAteIt/IAteIt/Model/Meal.swift
+++ b/IAteIt/IAteIt/Model/Meal.swift
@@ -21,7 +21,7 @@ struct Meal: Identifiable, Codable {
 extension Meal {
     static let meals = [
         Meal(id: "meal1", userId: "user1", uploadDate: Date(), plates: [Plate.plates[0], Plate.plates[1]], comments: [Comment.comments[0]]),
-        Meal(id: "meal2", userId: "user2", uploadDate: Date(), plates: [Plate.plates[2]], comments: [Comment.comments[1], Comment.comments[2]])
+        Meal(id: "meal2", userId: "user2", uploadDate: Date(), plates: [Plate.plates[2]], comments: [Comment.comments[1], Comment.comments[2]]),
+        Meal(id: "meal3", userId: "user1", location: "맥도날드", caption: "맥모닝 맛있다", uploadDate: Date(), plates: [Plate.plates[3], Plate.plates[4]], comments: [Comment.comments[3], Comment.comments[4]])
     ]
-    
 }

--- a/IAteIt/IAteIt/Model/Meal.swift
+++ b/IAteIt/IAteIt/Model/Meal.swift
@@ -20,9 +20,9 @@ struct Meal: Identifiable, Codable, Hashable {
 
 extension Meal {
     static let meals = [
-        Meal(id: "meal1", userId: "user1", uploadDate: Date(), plates: [Plate.plates[0], Plate.plates[1]], comments: [Comment.comments[0]]),
-        Meal(id: "meal2", userId: "user2", uploadDate: Date(), plates: [Plate.plates[2]], comments: [Comment.comments[1], Comment.comments[2]]),
-        Meal(id: "meal3", userId: "user1", location: "맥도날드", caption: "맥모닝 맛있다", uploadDate: Date(), plates: [Plate.plates[3], Plate.plates[4]], comments: [Comment.comments[3], Comment.comments[4]]),
-        Meal(id: "meal4", userId: "user2", uploadDate: Date(), plates: [Plate.plates[4]])
+        Meal(id: "meal1", userId: "user1", uploadDate: Date()-60, plates: [Plate.plates[0], Plate.plates[1]], comments: [Comment.comments[0]]),
+        Meal(id: "meal2", userId: "user2", uploadDate: Date()-60*60, plates: [Plate.plates[2]], comments: [Comment.comments[1], Comment.comments[2]]),
+        Meal(id: "meal3", userId: "user1", location: "맥도날드", caption: "맥모닝 맛있다", uploadDate: Date()-60*60*4, plates: [Plate.plates[3], Plate.plates[4]], comments: [Comment.comments[3], Comment.comments[4]]),
+        Meal(id: "meal4", userId: "user2", uploadDate: Date()-60*60*12, plates: [Plate.plates[5]])
     ]
 }

--- a/IAteIt/IAteIt/Model/Meal.swift
+++ b/IAteIt/IAteIt/Model/Meal.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Meal: Identifiable, Codable {
+struct Meal: Identifiable, Codable, Hashable {
     var id: String
     var userId: String
     var location: String?
@@ -22,6 +22,7 @@ extension Meal {
     static let meals = [
         Meal(id: "meal1", userId: "user1", uploadDate: Date(), plates: [Plate.plates[0], Plate.plates[1]], comments: [Comment.comments[0]]),
         Meal(id: "meal2", userId: "user2", uploadDate: Date(), plates: [Plate.plates[2]], comments: [Comment.comments[1], Comment.comments[2]]),
-        Meal(id: "meal3", userId: "user1", location: "맥도날드", caption: "맥모닝 맛있다", uploadDate: Date(), plates: [Plate.plates[3], Plate.plates[4]], comments: [Comment.comments[3], Comment.comments[4]])
+        Meal(id: "meal3", userId: "user1", location: "맥도날드", caption: "맥모닝 맛있다", uploadDate: Date(), plates: [Plate.plates[3], Plate.plates[4]], comments: [Comment.comments[3], Comment.comments[4]]),
+        Meal(id: "meal4", userId: "user2", uploadDate: Date(), plates: [Plate.plates[4]])
     ]
 }

--- a/IAteIt/IAteIt/Model/Plate.swift
+++ b/IAteIt/IAteIt/Model/Plate.swift
@@ -21,7 +21,8 @@ extension Plate {
         Plate(id: "plate2", mealId: "meal1", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
         Plate(id: "plate3", mealId: "meal2", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
         Plate(id: "plate4", mealId: "meal3", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
-        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date())
+        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
+        Plate(id: "plate5", mealId: "meal4", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date())
     ]
     
 }

--- a/IAteIt/IAteIt/Model/Plate.swift
+++ b/IAteIt/IAteIt/Model/Plate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Plate: Identifiable, Codable {
+struct Plate: Identifiable, Codable, Hashable {
     let id: String
     let mealId: String
     var imageUrl: String
@@ -19,7 +19,9 @@ extension Plate {
     static let plates: [Plate] = [
         Plate(id: "plate1", mealId: "meal1", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
         Plate(id: "plate2", mealId: "meal1", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
-        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date())
+        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
+        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
+        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date())
     ]
     
 }

--- a/IAteIt/IAteIt/Model/Plate.swift
+++ b/IAteIt/IAteIt/Model/Plate.swift
@@ -17,12 +17,12 @@ struct Plate: Identifiable, Codable, Hashable {
 
 extension Plate {
     static let plates: [Plate] = [
-        Plate(id: "plate1", mealId: "meal1", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
-        Plate(id: "plate2", mealId: "meal1", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
-        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
-        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://images.unsplash.com/photo-1525351326368-efbb5cb6814d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
+        Plate(id: "plate1", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
+        Plate(id: "plate2", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1572449043416-55f4685c9bb7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
+        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://images.unsplash.com/photo-1525351484163-7529414344d8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
+        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://images.unsplash.com/photo-1605851868183-7a4de52117fa?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
         Plate(id: "plate5", mealId: "meal3", imageUrl: "https://eatbook.sg/wp-content/uploads/2018/11/Marina-Square-Food-Beyond-Pancakes-min.png", uploadDate: Date()),
-        Plate(id: "plate5", mealId: "meal4", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date())
+        Plate(id: "plate5", mealId: "meal4", imageUrl: "https://images.unsplash.com/photo-1586190848861-99aa4a171e90?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date())
     ]
     
 }

--- a/IAteIt/IAteIt/Model/Plate.swift
+++ b/IAteIt/IAteIt/Model/Plate.swift
@@ -17,12 +17,12 @@ struct Plate: Identifiable, Codable, Hashable {
 
 extension Plate {
     static let plates: [Plate] = [
-        Plate(id: "plate1", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
-        Plate(id: "plate2", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1572449043416-55f4685c9bb7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
-        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://images.unsplash.com/photo-1525351484163-7529414344d8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
-        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://images.unsplash.com/photo-1605851868183-7a4de52117fa?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
-        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://eatbook.sg/wp-content/uploads/2018/11/Marina-Square-Food-Beyond-Pancakes-min.png", uploadDate: Date()),
-        Plate(id: "plate5", mealId: "meal4", imageUrl: "https://images.unsplash.com/photo-1586190848861-99aa4a171e90?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date())
+        Plate(id: "plate1", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()-60),
+        Plate(id: "plate2", mealId: "meal1", imageUrl: "https://images.unsplash.com/photo-1572449043416-55f4685c9bb7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()-30),
+        Plate(id: "plate3", mealId: "meal2", imageUrl: "https://images.unsplash.com/photo-1525351484163-7529414344d8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()-60*60),
+        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://images.unsplash.com/photo-1605851868183-7a4de52117fa?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()-60*60*4),
+        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://eatbook.sg/wp-content/uploads/2018/11/Marina-Square-Food-Beyond-Pancakes-min.png", uploadDate: Date()-60*60*4+30*60),
+        Plate(id: "plate5", mealId: "meal4", imageUrl: "https://images.unsplash.com/photo-1586190848861-99aa4a171e90?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()-60*60*12)
     ]
     
 }

--- a/IAteIt/IAteIt/Model/Plate.swift
+++ b/IAteIt/IAteIt/Model/Plate.swift
@@ -20,8 +20,8 @@ extension Plate {
         Plate(id: "plate1", mealId: "meal1", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
         Plate(id: "plate2", mealId: "meal1", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
         Plate(id: "plate3", mealId: "meal2", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
-        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date()),
-        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSK5q0FP74VV9wbfwP378_7kj7iDomHuKrxkXsxDdUT28V9dlVMNUe-EMzaLwaFhneeuZI&usqp=CAU", uploadDate: Date()),
+        Plate(id: "plate4", mealId: "meal3", imageUrl: "https://images.unsplash.com/photo-1525351326368-efbb5cb6814d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1480&q=80", uploadDate: Date()),
+        Plate(id: "plate5", mealId: "meal3", imageUrl: "https://eatbook.sg/wp-content/uploads/2018/11/Marina-Square-Food-Beyond-Pancakes-min.png", uploadDate: Date()),
         Plate(id: "plate5", mealId: "meal4", imageUrl: "https://cdn.shopify.com/app-store/listing_images/a78e004f44cded1b6998e7a6e081a230/promotional_image/CPKYl-_NivsCEAE=.png?height=720&width=1280", uploadDate: Date())
     ]
     

--- a/IAteIt/IAteIt/Model/User.swift
+++ b/IAteIt/IAteIt/Model/User.swift
@@ -16,7 +16,7 @@ struct User: Identifiable, Codable {
 
 extension User {
     static let users: [User] = [
-        User(id: "user1", nickname: "rain", profileImageUrl: "https://cdn.hswstatic.com/gif/google-update.jpg"),
+        User(id: "user1", nickname: "rain", profileImageUrl: "https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80"),
         User(id: "user2", nickname: "ThisfromHero")
     ]
     

--- a/IAteIt/IAteIt/Utility/Constants.swift
+++ b/IAteIt/IAteIt/Utility/Constants.swift
@@ -1,0 +1,12 @@
+//
+//  Constants.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/06.
+//
+
+import Foundation
+
+extension CGFloat {
+    public static let paddingHorizontal: CGFloat = 16
+}

--- a/IAteIt/IAteIt/Utility/Extension/DateFormatter.swift
+++ b/IAteIt/IAteIt/Utility/Extension/DateFormatter.swift
@@ -30,4 +30,10 @@ extension Date {
         let date_string = formatter.string(from: self)
         return date_string
     }
+    
+    func timeAgoDisplay() -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AddMealView: View {
     
-    let paddingLR: CGFloat = 16
-    
     var body: some View {
         ZStack {
             Button(action: {

--- a/IAteIt/IAteIt/View/Feed/Component/FeedFooterView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedFooterView.swift
@@ -8,27 +8,31 @@
 import SwiftUI
 
 struct FeedFooterView: View {
+    var meal: Meal
     
     var body: some View {
         
         HStack {
             VStack(alignment: .leading) {
-                Text("Caption")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                Text("View all comments")
-                    .font(.footnote)
-                    .fontWeight(.regular)
-                    .foregroundColor(.gray)
+                if let caption = meal.caption {
+                    Text(caption)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+                if meal.comments?.count ?? 0 > 0 {
+                    Text("View all comments")
+                        .font(.footnote)
+                        .fontWeight(.regular)
+                        .foregroundColor(.gray)
+                }
             }
             Spacer()
         }
-        .padding([.leading], 16)
     }
 }
 
 struct FeedFooterView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedFooterView()
+        FeedFooterView(meal: Meal.meals[2])
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -18,15 +18,24 @@ struct FeedHeaderView: View {
             HStack(alignment: .center, spacing: 12) {
                 if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
                     ZStack {
+                        if let userImage = User.users[indexOfUser].profileImageUrl {
                         Rectangle()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: profilePicSize, height: profilePicSize)
-                        if let image = User.users[indexOfUser].profileImageUrl {
-                            Image(image)
+                            AsyncImage(url: URL(string: userImage)) { image in
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .layoutPriority(-1)
+                                    .frame(width: profilePicSize, height: profilePicSize)
+                            } placeholder: {
+                                Color.gray
+                            }
+                        } else {
+                            Image(systemName: "person.crop.circle")
                                 .resizable()
-                                .scaledToFill()
-                                .layoutPriority(-1)
                                 .frame(width: profilePicSize, height: profilePicSize)
+                                .foregroundColor(.gray)
                         }
                     }
                     .clipped()

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -8,41 +8,47 @@
 import SwiftUI
 
 struct FeedHeaderView: View {
-    
     let profilePicSize: CGFloat = 36
-    var PostInfo: TempFeedHeader
-    var tempPlateList = TempPlateData().list
+    
+    var meal: Meal
+    var userId: String
     
     var body: some View {
         VStack {
             HStack(alignment: .center, spacing: 12) {
-                ZStack {
-                    Rectangle()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: profilePicSize, height: profilePicSize)
-                    Image(PostInfo.profileImage)
-                        .resizable()
-                        .scaledToFill()
-                        .layoutPriority(-1)
-                        .frame(width: profilePicSize, height: profilePicSize)
-                }
-                .clipped()
-                .cornerRadius(profilePicSize/2)
-                .padding([.top], 3)
-                
-                VStack(alignment: .leading) {
-                    Text(PostInfo.nickname)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    HStack(alignment: .bottom, spacing: 8) {
-                        Text("\(PostInfo.place) • \(PostInfo.time)")
-                            .font(.footnote)
+                if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
+                    ZStack {
+                        Rectangle()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: profilePicSize, height: profilePicSize)
+                        if let image = User.users[indexOfUser].profileImageUrl {
+                            Image(image)
+                                .resizable()
+                                .scaledToFill()
+                                .layoutPriority(-1)
+                                .frame(width: profilePicSize, height: profilePicSize)
+                        }
                     }
+                    .clipped()
+                    .cornerRadius(profilePicSize/2)
+                    .padding([.top], 3)
+                    
+                    VStack(alignment: .leading) {
+                        Text(User.users[indexOfUser].nickname)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+
+                            if let location = meal.location {
+                                Text("\(location) • \(meal.uploadDate.toTimeString())")
+                                    .font(.footnote)
+                            } else {
+                                Text(meal.uploadDate.toTimeString())
+                                    .font(.footnote)
+                            }
+                    }
+                    Spacer()
                 }
-                
-                Spacer()
             }
-            .padding([.leading], 16)
         }
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -11,12 +11,11 @@ struct FeedHeaderView: View {
     let profilePicSize: CGFloat = 36
     
     var meal: Meal
-    var userId: String
     
     var body: some View {
         VStack {
             HStack(alignment: .center, spacing: 12) {
-                if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
+                if let indexOfUser = User.users.firstIndex(where: { $0.id == meal.userId }) {
                     ZStack {
                         if let userImage = User.users[indexOfUser].profileImageUrl {
                         Rectangle()

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -48,10 +48,10 @@ struct FeedHeaderView: View {
                             .fontWeight(.semibold)
 
                             if let location = meal.location {
-                                Text("\(location) • \(meal.uploadDate.toTimeString())")
+                                Text("\(location) • \(meal.uploadDate.timeAgoDisplay())")
                                     .font(.footnote)
                             } else {
-                                Text(meal.uploadDate.toTimeString())
+                                Text(meal.uploadDate.timeAgoDisplay())
                                     .font(.footnote)
                             }
                     }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -25,7 +25,7 @@ struct FeedView: View {
                         .padding(.horizontal, paddingLR)
                     ForEach(mealList, id: \.self) { meal in
                         VStack(spacing: 8) {
-                            FeedHeaderView(meal: meal, userId: meal.userId)
+                            FeedHeaderView(meal: meal)
                                 .padding(.horizontal, paddingLR)
                             TabView {
                                 ForEach(meal.plates, id: \.self) { plate in

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -22,22 +22,25 @@ struct FeedView: View {
                 VStack(spacing: 27) {
                     AddMealView()
                         .padding([.top], 24)
+                        .padding(.horizontal, paddingLR)
                     ForEach(mealList, id: \.self) { meal in
                         VStack(spacing: 8) {
                             FeedHeaderView(meal: meal, userId: meal.userId)
+                                .padding(.horizontal, paddingLR)
                             TabView {
                                 ForEach(meal.plates, id: \.self) { plate in
                                     PhotoCardView(plate: plate)
+                                        .padding(.horizontal, paddingLR)
                                 }
                             }
                             .frame(minHeight: 358)
                             .tabViewStyle(.page)
                             FeedFooterView(meal: meal)
+                                .padding(.horizontal, paddingLR)
                         }
                     }
                 }
             }
-            .padding([.leading, .trailing], paddingLR)
             .navigationBarItems(leading:
                     FeedTitleView()
                     .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
@@ -46,7 +49,6 @@ struct FeedView: View {
                                     ProfilePhotoButtonView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
             )
         }
-        
 }
 
 struct FeedView_Previews: PreviewProvider {

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -13,30 +13,31 @@ struct FeedView: View {
     var tempFeedPhotoCardList = TempFeedPhotoCardData().list
     var tempPlateList = TempPlateData().list
     
+    var mealList = Meal.meals
+    
+    let paddingLR: CGFloat = 16
+    
     var body: some View {
-            ScrollView {
-                VStack{
-                    
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 27) {
                     AddMealView()
                         .padding([.top], 24)
-                        .padding([.bottom], 24)
-                        .padding([.leading, .trailing], 16)
-                    ForEach(tempFeedPhotoCardList, id: \.self) { postInfo in
-                        FeedHeaderView(PostInfo: postInfo)
-                            .padding([.bottom], 8)
-                        TabView {
-                            ForEach(tempPlateList, id: \.self) { plate in
-                                PhotoCardView(plate: plate)
+                    ForEach(mealList, id: \.self) { meal in
+                        VStack(spacing: 8) {
+                            FeedHeaderView(meal: meal, userId: meal.userId)
+                            TabView {
+                                ForEach(meal.plates, id: \.self) { plate in
+                                    PhotoCardView(plate: plate)
+                                }
                             }
+                            .frame(minHeight: 358)
+                            .tabViewStyle(.page)
+                            FeedFooterView(meal: meal)
                         }
-                        .frame(minHeight: 358)
-                        .tabViewStyle(.page)
-                        .padding([.bottom], 8)
-                        FeedFooterView()
-                            .padding([.bottom], 27)
                     }
                 }
             }
+            .padding([.leading, .trailing], paddingLR)
             .navigationBarItems(leading:
                     FeedTitleView()
                     .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -15,28 +15,26 @@ struct FeedView: View {
     
     var mealList = Meal.meals
     
-    let paddingLR: CGFloat = 16
-    
     var body: some View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 27) {
                     AddMealView()
                         .padding([.top], 24)
-                        .padding(.horizontal, paddingLR)
+                        .padding(.horizontal, .paddingHorizontal)
                     ForEach(mealList, id: \.self) { meal in
                         VStack(spacing: 8) {
                             FeedHeaderView(meal: meal)
-                                .padding(.horizontal, paddingLR)
+                                .padding(.horizontal, .paddingHorizontal)
                             TabView {
                                 ForEach(meal.plates, id: \.self) { plate in
                                     PhotoCardView(plate: plate)
-                                        .padding(.horizontal, paddingLR)
+                                        .padding(.horizontal, .paddingHorizontal)
                                 }
                             }
                             .frame(minHeight: 358)
                             .tabViewStyle(.page)
                             FeedFooterView(meal: meal)
-                                .padding(.horizontal, paddingLR)
+                                .padding(.horizontal, .paddingHorizontal)
                         }
                     }
                 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct AddCommentBarView: View {
     @State var commentInput: String = ""
     
-    let paddingLR: CGFloat = 16
-    
     var body: some View {
         VStack {
             Spacer()
@@ -20,7 +18,6 @@ struct AddCommentBarView: View {
                     .frame(height: 43)
                     .foregroundColor(.white)
                     .shadow(color: .black.opacity(0.10), radius: 20, x: 4, y: 4)
-                    .padding([.leading, .trailing], paddingLR)
                 HStack {
                     TextField("Add a comment...", text: $commentInput)
                         .font(.body)
@@ -33,7 +30,7 @@ struct AddCommentBarView: View {
                             .font(.body)
                     })
                 }
-                .padding([.leading, .trailing], 34)
+                .padding([.leading, .trailing], 18)
             }
         }
     }

--- a/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
@@ -11,11 +11,10 @@ struct CommentView: View {
     let profilePicSize: CGFloat = 36
     
     var comment: Comment
-    var userId: String
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
+            if let indexOfUser = User.users.firstIndex(where: { $0.id == comment.userId }) {
                 
                 ZStack {
                     if let userImage = User.users[indexOfUser].profileImageUrl {
@@ -62,6 +61,7 @@ struct CommentView: View {
 
 struct CommentView_Previews: PreviewProvider {
     static var previews: some View {
-        CommentView(comment: Comment.comments[3], userId: User.users[1].id)
+//        CommentView(comment: Comment.comments[3], userId: User.users[1].id)
+        CommentView(comment: Comment.comments[3])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
@@ -10,44 +10,49 @@ import SwiftUI
 struct CommentView: View {
     let profilePicSize: CGFloat = 36
     
-    var comment: TempComment
+    var comment: Comment
+    var userId: String
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            ZStack {
-                Rectangle()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: profilePicSize, height: profilePicSize)
-                Image(comment.profileImage)
-                    .resizable()
-                    .scaledToFill()
-                    .layoutPriority(-1)
-                    .frame(width: profilePicSize, height: profilePicSize)
-            }
-            .clipped()
-            .cornerRadius(profilePicSize/2)
-            .padding([.top], 3)
-            
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .bottom, spacing: 8) {
-                    Text(comment.nickname)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                    Text(comment.time)
-                        .font(.footnote)
-                        .foregroundColor(.gray)
+            if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
+                
+                ZStack {
+                    Rectangle()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: profilePicSize, height: profilePicSize)
+                    if let image = User.users[indexOfUser].profileImageUrl {
+                        Image(image)
+                            .resizable()
+                            .scaledToFill()
+                            .layoutPriority(-1)
+                            .frame(width: profilePicSize, height: profilePicSize)
+                    }
                 }
-                Text(comment.comment)
-                    .font(.subheadline)
+                .clipped()
+                .cornerRadius(profilePicSize/2)
+                .padding([.top], 3)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .bottom, spacing: 8) {
+                        Text(User.users[indexOfUser].nickname)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Text(comment.uploadDate.toTimeString())
+                            .font(.footnote)
+                            .foregroundColor(.gray)
+                    }
+                    Text(comment.comment)
+                        .font(.subheadline)
+                }
+                Spacer()
             }
-            
-            Spacer()
         }
     }
 }
 
 struct CommentView_Previews: PreviewProvider {
     static var previews: some View {
-        CommentView(comment: TempCommentData().list[0])
+        CommentView(comment: Comment.comments[3], userId: User.users[0].id)
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
@@ -13,7 +13,7 @@ struct CommentView: View {
     var comment: TempComment
     
     var body: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: .top, spacing: 12) {
             ZStack {
                 Rectangle()
                     .aspectRatio(contentMode: .fit)
@@ -40,7 +40,6 @@ struct CommentView: View {
                 Text(comment.comment)
                     .font(.subheadline)
             }
-            .padding([.leading], 12)
             
             Spacer()
         }

--- a/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/CommentView.swift
@@ -18,15 +18,24 @@ struct CommentView: View {
             if let indexOfUser = User.users.firstIndex(where: { $0.id == userId }) {
                 
                 ZStack {
-                    Rectangle()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: profilePicSize, height: profilePicSize)
-                    if let image = User.users[indexOfUser].profileImageUrl {
-                        Image(image)
-                            .resizable()
-                            .scaledToFill()
-                            .layoutPriority(-1)
+                    if let userImage = User.users[indexOfUser].profileImageUrl {
+                        Rectangle()
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: profilePicSize, height: profilePicSize)
+                        AsyncImage(url: URL(string: userImage)) { image in
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .layoutPriority(-1)
+                                .frame(width: profilePicSize, height: profilePicSize)
+                        } placeholder: {
+                            Color.gray
+                        }
+                    } else {
+                        Image(systemName: "person.crop.circle")
+                            .resizable()
+                            .frame(width: profilePicSize, height: profilePicSize)
+                            .foregroundColor(.gray)
                     }
                 }
                 .clipped()
@@ -53,6 +62,6 @@ struct CommentView: View {
 
 struct CommentView_Previews: PreviewProvider {
     static var previews: some View {
-        CommentView(comment: Comment.comments[3], userId: User.users[0].id)
+        CommentView(comment: Comment.comments[3], userId: User.users[1].id)
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
@@ -8,27 +8,33 @@
 import SwiftUI
 
 struct MealDetailTopView: View {
+    var meal: Meal
+    
     var body: some View {
         VStack(alignment: .center, spacing: 6) {
-                    HStack {
-                        Spacer()
-                        Text("2 hours ago")
-                            .font(.footnote)
-                            .foregroundColor(Color(UIColor.systemGray))
-                    }
-                    Text("맥모닝 맛있다")
-                        .font(.headline)
-                    HStack(alignment: .center, spacing: 4) {
-                        Image(systemName: "location.fill")
-                        Text("맥도날드")
-                    }
-                    .font(.subheadline)
+            HStack {
+                Spacer()
+                Text("2 hours ago")
+                    .font(.footnote)
+                    .foregroundColor(Color(UIColor.systemGray))
+            }
+            if let caption = meal.caption {
+                Text(caption)
+                    .font(.headline)
+            }
+            if let location = meal.location {
+                HStack(alignment: .center, spacing: 4) {
+                    Image(systemName: "location.fill")
+                    Text(location)
                 }
+                .font(.subheadline)
+            }
+        }
     }
 }
 
 struct MealDetailTopView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailTopView()
+        MealDetailTopView(meal: Meal.meals[3])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
@@ -1,0 +1,34 @@
+//
+//  MealDetailTopView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/04.
+//
+
+import SwiftUI
+
+struct MealDetailTopView: View {
+    var body: some View {
+        VStack(alignment: .center, spacing: 6) {
+                    HStack {
+                        Spacer()
+                        Text("2 hours ago")
+                            .font(.footnote)
+                            .foregroundColor(Color(UIColor.systemGray))
+                    }
+                    Text("맥모닝 맛있다")
+                        .font(.headline)
+                    HStack(alignment: .center, spacing: 4) {
+                        Image(systemName: "location.fill")
+                        Text("맥도날드")
+                    }
+                    .font(.subheadline)
+                }
+    }
+}
+
+struct MealDetailTopView_Previews: PreviewProvider {
+    static var previews: some View {
+        MealDetailTopView()
+    }
+}

--- a/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
@@ -35,6 +35,6 @@ struct MealDetailTopView: View {
 
 struct MealDetailTopView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailTopView(meal: Meal.meals[3])
+        MealDetailTopView(meal: Meal.meals[2])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
@@ -14,7 +14,7 @@ struct MealDetailTopView: View {
         VStack(alignment: .center, spacing: 6) {
             HStack {
                 Spacer()
-                Text("2 hours ago")
+                Text(meal.uploadDate.timeAgoDisplay())
                     .font(.footnote)
                     .foregroundColor(Color(UIColor.systemGray))
             }

--- a/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
@@ -10,57 +10,31 @@ import SwiftUI
 struct PhotoCardView: View {
     var plate: TempPlate
     
-    let tagImageLocation = "location"
-    let tagImageTime = "clock"
-    
-    let paddingLR: CGFloat = 16
     let photoCorner: CGFloat = 20
     
     var body: some View {
+        ZStack {
             ZStack {
-                ZStack {
-                    Rectangle()
-                        .aspectRatio(1, contentMode: .fit)
-                    Image(plate.image)
-                        .resizable()
-                        .scaledToFill()
-                        .layoutPriority(-1)
-                }
-                .clipped()
-                .cornerRadius(photoCorner)
-                
-                VStack {
-                    HStack {
-                        TagOnPhotoView(tagText: plate.location, tagImage: tagImageLocation)
-                        Spacer()
-                        TagOnPhotoView(tagText: plate.time, tagImage: tagImageTime)
-                    }
-                    .padding()
-                    
-                    Spacer()
-                    
-                    HStack {
-                        Spacer()
-                        Button(action: {
-                            // TODO: 내 포스팅에만 보이기, CameraView(upload) 연결
-                        }, label: {
-                            ZStack {
-                                Circle()
-                                    .opacity(0.6)
-                                    .frame(width: 36, height: 36)
-                                    .tint(.black)
-                                Image(systemName: "plus.circle")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 32, height: 32)
-                                    .foregroundColor(.white)
-                            }
-                        })
-                    }
-                    .padding()
-                }
+                Rectangle()
+                    .aspectRatio(1, contentMode: .fit)
+                Image(plate.image)
+                    .resizable()
+                    .scaledToFill()
+                    .layoutPriority(-1)
             }
-            .padding([.leading, .trailing], paddingLR)
+            .clipped()
+            .cornerRadius(photoCorner)
+            
+            VStack {
+                HStack {
+                    Spacer()
+                    TagOnPhotoView(tagText: plate.time)
+                }
+                .padding()
+                
+                Spacer()
+            }
+        }
     }
 }
 

--- a/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
@@ -17,10 +17,21 @@ struct PhotoCardView: View {
             ZStack {
                 Rectangle()
                     .aspectRatio(1, contentMode: .fit)
-                Image(plate.imageUrl)
-                    .resizable()
-                    .scaledToFill()
-                    .layoutPriority(-1)
+                    .cornerRadius(photoCorner)
+//                Image(plate.imageUrl)
+//                    .resizable()
+//                    .scaledToFill()
+//                    .layoutPriority(-1)
+                
+                AsyncImage(url: URL(string: plate.imageUrl)) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .layoutPriority(-1)
+                        .cornerRadius(photoCorner)
+                } placeholder: {
+                    Color.gray
+                }
             }
             .clipped()
             .cornerRadius(photoCorner)

--- a/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PhotoCardView: View {
-    var plate: TempPlate
+    var plate: Plate
     
     let photoCorner: CGFloat = 20
     
@@ -17,7 +17,7 @@ struct PhotoCardView: View {
             ZStack {
                 Rectangle()
                     .aspectRatio(1, contentMode: .fit)
-                Image(plate.image)
+                Image(plate.imageUrl)
                     .resizable()
                     .scaledToFill()
                     .layoutPriority(-1)
@@ -28,7 +28,7 @@ struct PhotoCardView: View {
             VStack {
                 HStack {
                     Spacer()
-                    TagOnPhotoView(tagText: plate.time)
+                    TagOnPhotoView(tagText: plate.uploadDate.toTimeString())
                 }
                 .padding()
                 
@@ -40,6 +40,6 @@ struct PhotoCardView: View {
 
 struct PhotoCardView_Previews: PreviewProvider {
     static var previews: some View {
-        PhotoCardView(plate: TempPlateData().list[0])
+        PhotoCardView(plate: Plate.plates[3])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/PhotoCardView.swift
@@ -18,10 +18,6 @@ struct PhotoCardView: View {
                 Rectangle()
                     .aspectRatio(1, contentMode: .fit)
                     .cornerRadius(photoCorner)
-//                Image(plate.imageUrl)
-//                    .resizable()
-//                    .scaledToFill()
-//                    .layoutPriority(-1)
                 
                 AsyncImage(url: URL(string: plate.imageUrl)) { image in
                     image

--- a/IAteIt/IAteIt/View/MealDetail/Component/TagOnPhotoView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/TagOnPhotoView.swift
@@ -24,6 +24,6 @@ struct TagOnPhotoView: View {
 
 struct TagOnPhotoView_Previews: PreviewProvider {
     static var previews: some View {
-        TagOnPhotoView(tagText: "07:40")
+        TagOnPhotoView(tagText: Plate.plates[3].uploadDate.toTimeString())
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/TagOnPhotoView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/TagOnPhotoView.swift
@@ -9,26 +9,21 @@ import SwiftUI
 
 struct TagOnPhotoView: View {
     var tagText: String
-    var tagImage: String
     
     var body: some View {
-        HStack(alignment: .center) {
-            Image(systemName: tagImage)
-                .font(.footnote)
-            Text(tagText)
-                .font(.footnote)
-        }
-        .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
-        .foregroundColor(.white)
-        .background(
-            RoundedRectangle(cornerRadius: 25)
-                .opacity(0.6)
-        )
+        Text(tagText)
+            .font(.footnote)
+            .padding(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+            .foregroundColor(.white)
+            .background(
+                RoundedRectangle(cornerRadius: 25)
+                    .opacity(0.6)
+            )
     }
 }
 
 struct TagOnPhotoView_Previews: PreviewProvider {
     static var previews: some View {
-        TagOnPhotoView(tagText: "맥도날드", tagImage: "location")
+        TagOnPhotoView(tagText: "07:40")
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -17,10 +17,12 @@ struct MealDetailView: View {
             ScrollView {
                 VStack {
                     MealDetailTopView(meal: meal)
+                        .padding(.horizontal, paddingLR)
                     
                     TabView {
                         ForEach(meal.plates, id: \.self) { plate in
                             PhotoCardView(plate: plate)
+                                .padding(.horizontal, paddingLR)
                         }
                     }
                     .frame(minHeight: 358)
@@ -33,13 +35,14 @@ struct MealDetailView: View {
                             }
                         }
                         .padding([.top], 24)
+                        .padding(.horizontal, paddingLR)
                     }
                 }
             }
             AddCommentBarView()
                 .padding([.bottom], 10)
+                .padding(.horizontal, paddingLR)
         }
-        .padding([.leading, .trailing], paddingLR)
     }
 }
 

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -18,12 +18,7 @@ struct MealDetailView: View {
         ZStack {
             ScrollView {
                 VStack {
-                    Text("맥모닝")
-                        .font(.headline)
-                        .padding(EdgeInsets(top: 8, leading: paddingLR, bottom: 1, trailing: paddingLR))
-                    Text("2 hours ago")
-                        .font(.footnote)
-                        .padding([.bottom], 8)
+                    MealDetailTopView()
                     
                     TabView {
                         ForEach(tempPlateList, id: \.self) { plate in
@@ -38,12 +33,13 @@ struct MealDetailView: View {
                             CommentView(comment: comment)
                         }
                     }
-                    .padding(EdgeInsets(top: 24, leading: paddingLR, bottom: 0, trailing: paddingLR))
+                    .padding([.top], 24)
                 }
             }
             AddCommentBarView()
                 .padding([.bottom], 10)
         }
+        .padding([.leading, .trailing], paddingLR)
     }
 }
 

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -8,10 +8,7 @@
 import SwiftUI
 
 struct MealDetailView: View {
-    var tempPlateList = TempPlateData().list
-    var tempCommentList = TempCommentData().list
-    
-    var mealData: Meal = Meal.meals[3]
+    var meal: Meal
     
     let paddingLR: CGFloat = 16
     
@@ -19,17 +16,17 @@ struct MealDetailView: View {
         ZStack {
             ScrollView {
                 VStack {
-                    MealDetailTopView(meal: mealData)
+                    MealDetailTopView(meal: meal)
                     
                     TabView {
-                        ForEach(mealData.plates, id: \.self) { plate in
+                        ForEach(meal.plates, id: \.self) { plate in
                             PhotoCardView(plate: plate)
                         }
                     }
                     .frame(minHeight: 358)
                     .tabViewStyle(.page)
                     
-                    if let comments = mealData.comments {
+                    if let comments = meal.comments {
                         VStack(alignment: .leading, spacing: 12) {
                             ForEach(comments, id: \.self) { comment in
                                 CommentView(comment: comment, userId: comment.userId)
@@ -48,6 +45,6 @@ struct MealDetailView: View {
 
 struct MealDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailView()
+        MealDetailView(meal: Meal.meals[2])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -10,19 +10,17 @@ import SwiftUI
 struct MealDetailView: View {
     var meal: Meal
     
-    let paddingLR: CGFloat = 16
-    
     var body: some View {
         ZStack {
             ScrollView {
                 VStack {
                     MealDetailTopView(meal: meal)
-                        .padding(.horizontal, paddingLR)
+                        .padding(.horizontal, .paddingHorizontal)
                     
                     TabView {
                         ForEach(meal.plates, id: \.self) { plate in
                             PhotoCardView(plate: plate)
-                                .padding(.horizontal, paddingLR)
+                                .padding(.horizontal, .paddingHorizontal)
                         }
                     }
                     .frame(minHeight: 358)
@@ -35,13 +33,13 @@ struct MealDetailView: View {
                             }
                         }
                         .padding([.top], 24)
-                        .padding(.horizontal, paddingLR)
+                        .padding(.horizontal, .paddingHorizontal)
                     }
                 }
             }
             AddCommentBarView()
                 .padding([.bottom], 10)
-                .padding(.horizontal, paddingLR)
+                .padding(.horizontal, .paddingHorizontal)
         }
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -11,29 +11,32 @@ struct MealDetailView: View {
     var tempPlateList = TempPlateData().list
     var tempCommentList = TempCommentData().list
     
+    var mealData: Meal = Meal.meals[3]
+    
     let paddingLR: CGFloat = 16
-    let photoCorner: CGFloat = 20
     
     var body: some View {
         ZStack {
             ScrollView {
                 VStack {
-                    MealDetailTopView()
+                    MealDetailTopView(meal: mealData)
                     
                     TabView {
-                        ForEach(tempPlateList, id: \.self) { plate in
+                        ForEach(mealData.plates, id: \.self) { plate in
                             PhotoCardView(plate: plate)
                         }
                     }
                     .frame(minHeight: 358)
                     .tabViewStyle(.page)
                     
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(tempCommentList, id: \.self) { comment in
-                            CommentView(comment: comment)
+                    if let comments = mealData.comments {
+                        VStack(alignment: .leading, spacing: 12) {
+                            ForEach(comments, id: \.self) { comment in
+                                CommentView(comment: comment, userId: comment.userId)
+                            }
                         }
+                        .padding([.top], 24)
                     }
-                    .padding([.top], 24)
                 }
             }
             AddCommentBarView()

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -31,7 +31,7 @@ struct MealDetailView: View {
                     if let comments = meal.comments {
                         VStack(alignment: .leading, spacing: 12) {
                             ForEach(comments, id: \.self) { comment in
-                                CommentView(comment: comment, userId: comment.userId)
+                                CommentView(comment: comment)
                             }
                         }
                         .padding([.top], 24)


### PR DESCRIPTION
## 관련 이슈들
- #14 #21 

## 작업 내용
- MealDetailView UI를 업데이트했습니다. (예전에 결정된 사진 위 +버튼 없애기, 장소는 meal 당 하나 등)
- FeedView, MealDetailView가 결정된 데이터 모델로 그려지도록 수정했습니다.

## 리뷰 노트
- 뷰 외 로직적인 부분은 별도 Manager 같은 파일을 만들어서 빼보려고 했는데 어떤 부분을 따로 빼야할지 판단이 어렵기도 하고 아직은 큰 로직이 없는 것 같기도 하고(?) 해서 모두 뷰 안에 작성했습니다.. 아래 같은 항목도 뷰와 분리하는 것이 좋았을까요?
  - MealDetail에서 comment를 표시할 때 코멘트한 사람의 닉네임과 사진을 표시하기 위해 `Comment.userId`를 `User.id`에서 찾기

### 작업되지 못한 것들
- 이슈 #14 의 왼쪽으로 사진 밀어서 plate 추가하기 기능은 좀더 공부해서 구현해야 할 것 같습니다ㅜㅜ
- 이슈 #21 의 네비게이션 연결은 아직 안된 상태입니다.

## 스크린샷(UX의 경우 gif)
<p list="left">
<img width="300" alt="Screenshot 2023-04-05 at 12 46 11 PM" src="https://user-images.githubusercontent.com/103012157/229976181-70503f88-66b5-4bd7-8cbf-98d5fa97bc4a.png">
<img width="300" alt="Screenshot 2023-04-05 at 12 44 36 PM" src="https://user-images.githubusercontent.com/103012157/229975996-404fcf87-7fbf-4719-a2af-fac438fd3923.png">
</p>
<p list="left">
<img src="https://user-images.githubusercontent.com/103012157/229975728-0c3fa19f-f080-415e-9a5e-4bb32216447e.gif" width="300">
<img src="https://user-images.githubusercontent.com/103012157/229975820-5f3d41c3-b19c-4e2a-ab99-a4ec7f000b8e.gif" width="300">
</p>

## Reference
- [URL 이미지 표시하기](https://velog.io/@guel/SwiftUI-AsyncImage)
- [x hours ago 표시하기](https://stackoverflow.com/questions/44086555/swift-display-time-ago-from-date-nsdate)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
