### PR TITLE
[Feat] #28 SignUpView UI 작업

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -546,10 +546,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = IAteIt/IAteIt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 44Q9HUN6LA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";
@@ -568,6 +570,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Bnomad.IAteIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = IAteItProvisioningProfile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -581,10 +584,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = IAteIt/IAteIt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"IAteIt/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 44Q9HUN6LA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "이 앱은 사진을 촬영하기 위해 카메라를 사용합니다. 카메라 접근 권한을 허용해 주세요.";
@@ -603,6 +608,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Bnomad.IAteIt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = IAteItProvisioningProfile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
 		7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */; };
 		7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */; };
+		7E9FEF3729DEBAA9002E7211 /* SignUpSecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3629DEBAA9002E7211 /* SignUpSecondView.swift */; };
+		7E9FEF3929DF12EF002E7211 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3829DF12EF002E7211 /* ImagePicker.swift */; };
 		7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28729A5228D0021B9FE /* IAteItApp.swift */; };
 		7EFFE28A29A5228D0021B9FE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28929A5228D0021B9FE /* ContentView.swift */; };
 		7EFFE28C29A5228F0021B9FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28B29A5228F0021B9FE /* Assets.xcassets */; };
@@ -76,6 +78,8 @@
 		7E9198A429CF591200044815 /* IAteIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IAteIt.entitlements; sourceTree = "<group>"; };
 		7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+Extension.swift"; sourceTree = "<group>"; };
 		7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
+		7E9FEF3629DEBAA9002E7211 /* SignUpSecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpSecondView.swift; sourceTree = "<group>"; };
+		7E9FEF3829DF12EF002E7211 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		7EFFE28429A5228D0021B9FE /* IAteIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IAteIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EFFE28729A5228D0021B9FE /* IAteItApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAteItApp.swift; sourceTree = "<group>"; };
 		7EFFE28929A5228D0021B9FE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -135,6 +139,7 @@
 			children = (
 				7E9FEF3329DEA052002E7211 /* Component */,
 				7E6069CC29A5CADE00284CBD /* SignUpView.swift */,
+				7E9FEF3629DEBAA9002E7211 /* SignUpSecondView.swift */,
 				7E9198A229CF56B400044815 /* LoginView.swift */,
 			);
 			path = SignUp;
@@ -197,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				7E6069DA29A5CB2800284CBD /* Extension */,
+				7E9FEF3829DF12EF002E7211 /* ImagePicker.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -369,6 +375,7 @@
 				DF883D4629B58F3D0029DC60 /* Plate.swift in Sources */,
 				7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */,
 				6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */,
+				7E9FEF3729DEBAA9002E7211 /* SignUpSecondView.swift in Sources */,
 				DFD52CE429CB127D00E86F9F /* Meal.swift in Sources */,
 				7E6069D829A5CB1000284CBD /* TempModel.swift in Sources */,
 				04C1189529B74DD60073EDB7 /* TempFeedHeader.swift in Sources */,
@@ -401,6 +408,7 @@
 				7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */,
 				048750A529B8ABA1006836D1 /* FeedTitleView.swift in Sources */,
 				7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */,
+				7E9FEF3929DF12EF002E7211 /* ImagePicker.swift in Sources */,
 				DF2213A529BB324F000134FC /* FirebaseConnector.swift in Sources */,
 				7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */,
 			);

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -30,17 +30,19 @@
 		7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */; };
 		7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */; };
 		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
+		7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */; };
+		7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */; };
 		7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28729A5228D0021B9FE /* IAteItApp.swift */; };
 		7EFFE28A29A5228D0021B9FE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFFE28929A5228D0021B9FE /* ContentView.swift */; };
 		7EFFE28C29A5228F0021B9FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28B29A5228F0021B9FE /* Assets.xcassets */; };
 		7EFFE28F29A5228F0021B9FE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7EFFE28E29A5228F0021B9FE /* Preview Assets.xcassets */; };
+		8C73F00329BDD010007D1A1E /* DailyMealCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */; };
+		8C73F00529BDDAE6007D1A1E /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */; };
 		DF22139B29BB2843000134FC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DF22139A29BB2843000134FC /* GoogleService-Info.plist */; };
 		DF22139E29BB293C000134FC /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = DF22139D29BB293C000134FC /* FirebaseFirestore */; };
 		DF2213A029BB293C000134FC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = DF22139F29BB293C000134FC /* FirebaseStorage */; };
 		DF2213A229BB2ADC000134FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A129BB2ADC000134FC /* AppDelegate.swift */; };
 		DF2213A529BB324F000134FC /* FirebaseConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A429BB324F000134FC /* FirebaseConnector.swift */; };
-		8C73F00329BDD010007D1A1E /* DailyMealCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */; };
-		8C73F00529BDDAE6007D1A1E /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */; };
 		DF883D4229B58F2C0029DC60 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4129B58F2C0029DC60 /* User.swift */; };
 		DF883D4629B58F3D0029DC60 /* Plate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4529B58F3D0029DC60 /* Plate.swift */; };
 		DF883D4829B58F430029DC60 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4729B58F430029DC60 /* Comment.swift */; };
@@ -72,16 +74,18 @@
 		7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOnPhotoView.swift; sourceTree = "<group>"; };
 		7E9198A229CF56B400044815 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		7E9198A429CF591200044815 /* IAteIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IAteIt.entitlements; sourceTree = "<group>"; };
+		7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+Extension.swift"; sourceTree = "<group>"; };
+		7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		7EFFE28429A5228D0021B9FE /* IAteIt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IAteIt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7EFFE28729A5228D0021B9FE /* IAteItApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAteItApp.swift; sourceTree = "<group>"; };
 		7EFFE28929A5228D0021B9FE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7EFFE28B29A5228F0021B9FE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7EFFE28E29A5228F0021B9FE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMealCellView.swift; sourceTree = "<group>"; };
+		8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		DF22139A29BB2843000134FC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		DF2213A129BB2ADC000134FC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DF2213A429BB324F000134FC /* FirebaseConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseConnector.swift; sourceTree = "<group>"; };
-		8C73F00229BDD010007D1A1E /* DailyMealCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMealCellView.swift; sourceTree = "<group>"; };
-		8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
 		DF883D4129B58F2C0029DC60 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DF883D4529B58F3D0029DC60 /* Plate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plate.swift; sourceTree = "<group>"; };
 		DF883D4729B58F430029DC60 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
@@ -129,6 +133,7 @@
 		7E6069C729A5CA7400284CBD /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
+				7E9FEF3329DEA052002E7211 /* Component */,
 				7E6069CC29A5CADE00284CBD /* SignUpView.swift */,
 				7E9198A229CF56B400044815 /* LoginView.swift */,
 			);
@@ -201,6 +206,7 @@
 			children = (
 				7E6069DB29A5CB3A00284CBD /* TempExtension.swift */,
 				8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */,
+				7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -223,6 +229,14 @@
 				7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */,
 				7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */,
 				7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		7E9FEF3329DEA052002E7211 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -365,6 +379,7 @@
 				7E6069CD29A5CADE00284CBD /* SignUpView.swift in Sources */,
 				DF883D4829B58F430029DC60 /* Comment.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
+				7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */,
 				8C73F00329BDD010007D1A1E /* DailyMealCellView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				DF883D4229B58F2C0029DC60 /* User.swift in Sources */,
@@ -373,6 +388,7 @@
 				630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */,
 				7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */,
 				04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */,
+				7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */,

--- a/IAteIt/IAteIt/Utility/Extension/TextField+Extension.swift
+++ b/IAteIt/IAteIt/Utility/Extension/TextField+Extension.swift
@@ -1,0 +1,28 @@
+//
+//  TextField+Extension.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/06.
+//
+
+import SwiftUI
+
+struct TextLengthLimiter: ViewModifier {
+  @Binding var text: String
+  let maxLength: Int
+
+  func body(content: Content) -> some View {
+    content
+      .onReceive(text.publisher.collect()) { output in
+        text = String(output.prefix(maxLength)) // HERE
+      }
+  }
+}
+
+extension TextField {
+  func limitTextLength(_ text: Binding<String>,
+                       to maxLength: Int) -> some View {
+    self.modifier(TextLengthLimiter(text: text,
+                                    maxLength: maxLength))
+  }
+}

--- a/IAteIt/IAteIt/Utility/ImagePicker.swift
+++ b/IAteIt/IAteIt/Utility/ImagePicker.swift
@@ -1,0 +1,40 @@
+//
+//  ImagePicker.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/06.
+//
+
+import SwiftUI
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Binding var image: UIImage?
+    @Environment(\.presentationMode) var mode
+    
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+    }
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: ImagePicker
+        
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            guard let image = info[.originalImage] as? UIImage else { return }
+            self.parent.image = image
+            self.parent.mode.wrappedValue.dismiss()
+        }
+    }
+}

--- a/IAteIt/IAteIt/View/SignUp/Component/BottomButtonView.swift
+++ b/IAteIt/IAteIt/View/SignUp/Component/BottomButtonView.swift
@@ -1,0 +1,24 @@
+//
+//  BottomButtonView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/06.
+//
+
+import SwiftUI
+
+struct BottomButtonView: View {
+    var label: String
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .accentColor(.black)
+            Text(label)
+                .font(.headline)
+                .foregroundColor(.white)
+        }
+        .frame(width: 350, height: 48)
+        .padding(.bottom, 12)
+    }
+}

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct SignUpSecondView: View {
+    @State private var imagePickerPresented = false
+    @State private var selectedImage: UIImage?
+    @State private var profileImage: Image?
+    @State private var isLaterTextPresented = true
+    
     let imgSize: CGFloat = 148
     
     var body: some View {
@@ -16,38 +21,57 @@ struct SignUpSecondView: View {
                 .font(.headline)
                 .padding(.top, 60)
             Button(action: {
-                // TODO: 이미지 선택
+                imagePickerPresented.toggle()
             }, label: {
-                ZStack {
-                    Rectangle()
-                        .foregroundColor(.white)
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: imgSize, height: imgSize)
-                    Image(systemName: "person.crop.circle")
+                if let image = profileImage {
+                    image
                         .resizable()
                         .scaledToFill()
-                        .layoutPriority(-1)
                         .frame(width: imgSize, height: imgSize)
-                        .foregroundColor(Color(UIColor.systemGray2))
+                        .clipShape(Circle())
+                } else {
+                    ZStack {
+                        Rectangle()
+                            .foregroundColor(.white)
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: imgSize, height: imgSize)
+                        Image(systemName: "person.crop.circle")
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: imgSize, height: imgSize)
+                            .foregroundColor(Color(UIColor.systemGray2))
+                    }
+                    .clipShape(Circle())
                 }
-                .clipped()
-                .cornerRadius(imgSize/2)
             })
+            .sheet(isPresented: $imagePickerPresented,
+                   onDismiss: loadImage,
+                   content: { ImagePicker(image: $selectedImage) })
             .shadow(color: .black.opacity(0.20), radius: 10, x: 4, y: 4)
             .padding(.top, 40)
             
             Spacer()
-            Text("You can do this later!")
-                .font(.body)
-                .foregroundColor(Color(UIColor.systemGray))
-                .padding(.bottom, 20)
+            if isLaterTextPresented {
+                Text("You can do this later!")
+                    .font(.body)
+                    .foregroundColor(Color(UIColor.systemGray))
+                    .padding(.bottom, 20)
+            }
             Button(action: {
-                // TODO: 이미지 저장, dismiss
+                // TODO: 이미지 저장, SignUpView dismiss
             }, label: {
                 BottomButtonView(label: "Done")
             })
         }
         .navigationBarHidden(true)
+    }
+}
+
+extension SignUpSecondView {
+    func loadImage() {
+        guard let selectedImage = selectedImage else { return }
+        profileImage = Image(uiImage: selectedImage)
+        isLaterTextPresented = false
     }
 }
 

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -1,0 +1,58 @@
+//
+//  SignUpSecondView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/04/06.
+//
+
+import SwiftUI
+
+struct SignUpSecondView: View {
+    let imgSize: CGFloat = 148
+    
+    var body: some View {
+        VStack {
+            Text("Please upload your profile picture.")
+                .font(.headline)
+                .padding(.top, 60)
+            Button(action: {
+                // TODO: 이미지 선택
+            }, label: {
+                ZStack {
+                    Rectangle()
+                        .foregroundColor(.white)
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: imgSize, height: imgSize)
+                    Image(systemName: "person.crop.circle")
+                        .resizable()
+                        .scaledToFill()
+                        .layoutPriority(-1)
+                        .frame(width: imgSize, height: imgSize)
+                        .foregroundColor(Color(UIColor.systemGray2))
+                }
+                .clipped()
+                .cornerRadius(imgSize/2)
+            })
+            .shadow(color: .black.opacity(0.20), radius: 10, x: 4, y: 4)
+            .padding(.top, 40)
+            
+            Spacer()
+            Text("You can do this later!")
+                .font(.body)
+                .foregroundColor(Color(UIColor.systemGray))
+                .padding(.bottom, 20)
+            Button(action: {
+                // TODO: 이미지 저장, dismiss
+            }, label: {
+                BottomButtonView(label: "Done")
+            })
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+struct SignUpSecondView_Previews: PreviewProvider {
+    static var previews: some View {
+        SignUpSecondView()
+    }
+}

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SignUpView: View {
     @State private var username = ""
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         VStack {
@@ -18,6 +19,10 @@ struct SignUpView: View {
             TextField("username", text: $username)
                 .limitTextLength($username, to: 16)
                 .textInputAutocapitalization(.never)
+                .focused($isFocused)
+                .onAppear() {
+                    isFocused = true
+                }
                 .onChange(of: username) { _ in
                     username = username.replacingOccurrences(of: " ", with: "")
                 }
@@ -31,13 +36,15 @@ struct SignUpView: View {
         }
         .overlay {
             VStack {
-            Spacer()
-                Button(action: {
-                    // TODO: username 저장, 다음 뷰로 넘기기
-                }, label: {
+                Spacer()
+                NavigationLink(destination: SignUpSecondView()
+                    , label: {
                     BottomButtonView(label: "Next")
                 })
-                .disabled(username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || username.count < 3)
+                .simultaneousGesture(TapGesture().onEnded {
+                    //TODO: username 저장
+                })
             }
         }
     }

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -37,6 +37,10 @@ struct SignUpView: View {
         .overlay {
             VStack {
                 Spacer()
+                Text("Username must be between 3 and 16 characters.")
+                    .font(.subheadline)
+                    .foregroundColor(Color(UIColor.systemGray))
+                    .padding(.bottom, 20)
                 NavigationLink(destination: SignUpSecondView()
                     , label: {
                     BottomButtonView(label: "Next")

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -8,8 +8,38 @@
 import SwiftUI
 
 struct SignUpView: View {
+    @State private var username = ""
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("Please create your username.")
+                .font(.headline)
+                .padding(.top, 60)
+            TextField("username", text: $username)
+                .limitTextLength($username, to: 16)
+                .textInputAutocapitalization(.never)
+                .onChange(of: username) { _ in
+                    username = username.replacingOccurrences(of: " ", with: "")
+                }
+                .font(Font.title2.weight(.bold))
+                .multilineTextAlignment(.center)
+                .padding(.top, 40)
+            Text("\(username.count) / 16")
+                .font(.caption2)
+                .foregroundColor(.gray)
+            Spacer()
+        }
+        .overlay {
+            VStack {
+            Spacer()
+                Button(action: {
+                    // TODO: username 저장, 다음 뷰로 넘기기
+                }, label: {
+                    BottomButtonView(label: "Next")
+                })
+                .disabled(username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 관련 이슈들
- #28 

## 작업 내용
- 최초 애플로그인 후 만나게 되는 SignUpView UI를 작업했습니다.
- username 글자 제한(3~16자, 공백불가), 프로필이미지 image picker 등 반영했습니다.

## 리뷰 노트
- 이번에도 뷰를 그리기 위한 로직을 담는 manager 파일을 분리하지 못했습니다.. 
- B.nomad때는 UIKit으로 회원가입뷰 했었는데 SwiftUI로 하니 재밌네요....

## 스크린샷(UX의 경우 gif)
<p list="left">
<img width="300" alt="Screenshot 2023-04-07 at 12 28 16 AM" src="https://user-images.githubusercontent.com/103012157/230426540-dc44cd38-e84d-4c76-8a75-c0415c36714f.png">
<img width="300" alt="Screenshot 2023-04-07 at 12 28 36 AM" src="https://user-images.githubusercontent.com/103012157/230426536-3c59dd8b-c9fb-4f75-8ed8-4be418ea561e.png">
</p>

<img src="https://user-images.githubusercontent.com/103012157/230426015-e9b3b95d-dec4-4f46-add7-213bdfaf5059.gif" width="300">

## Reference
- [TextField 글자수 제한하기](https://swiftuirecipes.com/blog/swiftui-limit-text-length-in-textfield)
- [ImagePicker 사용하기](https://velog.io/@leeesangheee/ImagePicker-사용하기)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
