### PR TITLE
[Feat] 피드뷰 내비게이션 단순 연결

### DIFF
--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -11,14 +11,14 @@ struct AddMealView: View {
     
     var body: some View {
         ZStack {
-            Button(action: {
-                // TODO: 끼니 추가 액션
-            }, label: {
+//            Button(action: {
+//                // TODO: 끼니 추가 액션
+//            }, label: {
                 RoundedRectangle(cornerRadius: 20)
                     .frame(height: 50)
                     .foregroundColor(.white)
                     .shadow(color: .black.opacity(0.10), radius: 10, x: 4, y: 4)
-            })
+//            })
             HStack(spacing: 12) {
                 Image(systemName: "camera")
                     .tint(.black)

--- a/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/AddMealView.swift
@@ -11,14 +11,10 @@ struct AddMealView: View {
     
     var body: some View {
         ZStack {
-//            Button(action: {
-//                // TODO: 끼니 추가 액션
-//            }, label: {
                 RoundedRectangle(cornerRadius: 20)
                     .frame(height: 50)
                     .foregroundColor(.white)
                     .shadow(color: .black.opacity(0.10), radius: 10, x: 4, y: 4)
-//            })
             HStack(spacing: 12) {
                 Image(systemName: "camera")
                     .tint(.black)

--- a/IAteIt/IAteIt/View/Feed/Component/ProfilePhotoButtonView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/ProfilePhotoButtonView.swift
@@ -12,9 +12,9 @@ struct ProfilePhotoButtonView: View {
     var profileInfo: TempFeedHeader //TODO: 프로필 데이터 수정
     
     var body: some View {
-        Button {
-            //TODO: 프로필 내비게이션
-        } label: {
+//        Button {
+//            //TODO: 프로필 내비게이션
+//        } label: {
             ZStack{
                 Rectangle()
                     .aspectRatio(contentMode: .fit)
@@ -29,5 +29,5 @@ struct ProfilePhotoButtonView: View {
             .cornerRadius(14)
             .padding([.top], 3)
         }
-    }
+//    }
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -50,6 +50,7 @@ struct FeedView: View {
                     }
                 }
             }
+            
             .navigationBarItems(leading:
                                     FeedTitleView()
                 .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -16,37 +16,49 @@ struct FeedView: View {
     var mealList = Meal.meals
     
     var body: some View {
+        NavigationView() {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 27) {
-                    AddMealView()
-                        .padding([.top], 24)
-                        .padding(.horizontal, .paddingHorizontal)
+                    NavigationLink(destination: CameraView()) {
+                        AddMealView()
+                            .padding([.top], 24)
+                            .padding(.horizontal, .paddingHorizontal)
+                    }
+                    .buttonStyle(PlainButtonStyle()) //버튼스타일 메소드 삭제하려면 컴포넌트 자체에서 지정해주어야
                     ForEach(mealList, id: \.self) { meal in
                         VStack(spacing: 8) {
                             FeedHeaderView(meal: meal)
                                 .padding(.horizontal, .paddingHorizontal)
-                            TabView {
-                                ForEach(meal.plates, id: \.self) { plate in
-                                    PhotoCardView(plate: plate)
-                                        .padding(.horizontal, .paddingHorizontal)
+                            NavigationLink(destination: MealDetailView(meal: Meal.meals[2])) {
+                                TabView {
+                                    ForEach(meal.plates, id: \.self) { plate in
+                                        PhotoCardView(plate: plate)
+                                            .padding(.horizontal, .paddingHorizontal)
+                                    }
                                 }
                             }
+                            .buttonStyle(PlainButtonStyle())
                             .frame(minHeight: 358)
                             .tabViewStyle(.page)
-                            FeedFooterView(meal: meal)
-                                .padding(.horizontal, .paddingHorizontal)
+                            NavigationLink(destination: MealDetailView(meal: Meal.meals[2])) {
+                                //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
+                                FeedFooterView(meal: meal)
+                                    .padding(.horizontal, .paddingHorizontal)
+                            }
+                            .buttonStyle(PlainButtonStyle())
                         }
                     }
                 }
             }
             .navigationBarItems(leading:
-                    FeedTitleView()
-                    .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
+                                    FeedTitleView()
+                .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
             )
-            .navigationBarItems(trailing:
-                                    ProfilePhotoButtonView(profileInfo: tempFeedPhotoCardList[0]) //TODO: 프로필사진 연결
-            )
+            .navigationBarItems(trailing: NavigationLink(destination: MyProfileView()) {
+                ProfilePhotoButtonView(profileInfo: tempFeedPhotoCardList[0])
+            })
         }
+    }
 }
 
 struct FeedView_Previews: PreviewProvider {


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- 피드뷰에서 MealDatailView / CameraView / MyProfileView 로의 내비게이션 단순 연결
- 앱 타이틀 재생성

## 리뷰 노트
- 다크모드 라이트모드 나누는 등 컴포넌트 색상에 대해 아직 어떻게 할지 몰라서 따로 메소드로 plainStyle을 적용해서 파란색 하이라이트를 지웠습니다.

## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2023-04-07 17 09 05" src="https://user-images.githubusercontent.com/70618615/230569753-86d6db05-d9a2-4b88-9545-db206ba60e3a.png">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
