### PR TITLE
[Feat] #44 Meal에 Plate 추가, 캡션/장소 저장

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		7E407CCC2A044D1B001CAFBF /* FeedMealModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E407CCB2A044D1B001CAFBF /* FeedMealModel.swift */; };
 		7E407CCE2A04F682001CAFBF /* AuthDataResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E407CCD2A04F682001CAFBF /* AuthDataResultModel.swift */; };
 		7E407CD02A0558A3001CAFBF /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7E407CCF2A0558A3001CAFBF /* FirebaseFirestoreSwift */; };
+		7E407CD22A0BEBEF001CAFBF /* AddPlateButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E407CD12A0BEBEF001CAFBF /* AddPlateButtonView.swift */; };
 		7E42C95729DC112B00ABE32D /* MealDetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */; };
 		7E48DC1C29F42F3E0079E896 /* FirebaseConnector+ExtensionForMeals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E48DC1B29F42F3E0079E896 /* FirebaseConnector+ExtensionForMeals.swift */; };
 		7E48DC1E29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E48DC1D29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift */; };
@@ -81,6 +82,7 @@
 		7E2B2DAC29DE9304009EC0ED /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7E407CCB2A044D1B001CAFBF /* FeedMealModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedMealModel.swift; sourceTree = "<group>"; };
 		7E407CCD2A04F682001CAFBF /* AuthDataResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataResultModel.swift; sourceTree = "<group>"; };
+		7E407CD12A0BEBEF001CAFBF /* AddPlateButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPlateButtonView.swift; sourceTree = "<group>"; };
 		7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealDetailTopView.swift; sourceTree = "<group>"; };
 		7E48DC1B29F42F3E0079E896 /* FirebaseConnector+ExtensionForMeals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseConnector+ExtensionForMeals.swift"; sourceTree = "<group>"; };
 		7E48DC1D29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseConnector+ExtensionForComments.swift"; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */,
 				7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */,
 				7E42C95629DC112B00ABE32D /* MealDetailTopView.swift */,
+				7E407CD12A0BEBEF001CAFBF /* AddPlateButtonView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 				630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */,
 				7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */,
 				04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */,
+				7E407CD22A0BEBEF001CAFBF /* AddPlateButtonView.swift in Sources */,
 				7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,

--- a/IAteIt/IAteIt/Application/IAteItApp.swift
+++ b/IAteIt/IAteIt/Application/IAteItApp.swift
@@ -18,7 +18,9 @@ struct IAteItApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationView {
-                FeedView(loginState: loginState, feedMeals: feedMeals)
+                FeedView()
+                    .environmentObject(loginState)
+                    .environmentObject(feedMeals)
             }
         }
     }

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -50,20 +50,20 @@ extension FirebaseConnector {
     }
     
     // 특정 meal에 caption 업데이트
-    func setMealCaption(mealId: String, caption: String) {
-        FirebaseConnector.meals.document(mealId).updateData([
+    func setMealCaption(mealId: String, caption: String) async {
+        try? await FirebaseConnector.meals.document(mealId).updateData([
             "caption": caption as Any
         ])
     }
     
     // 특정 meal에 location 업데이트
-    func setMealLocation(mealId: String, location: String) {
-        FirebaseConnector.meals.document(mealId).updateData([
+    func setMealLocation(mealId: String, location: String) async {
+        try? await FirebaseConnector.meals.document(mealId).updateData([
             "location": location as Any
         ])
     }
     
-    // 특정 user의 모든 meal 데이터 가져오기 (plate는 따로 fetchMealPlates로 가져와야함..)
+    // 특정 user의 모든 meal 데이터 가져오기
     func fetchUserMealHistory(userId: String, completion: @escaping([Meal]) -> Void) {
         var mealHistory: [Meal] = []
         

--- a/IAteIt/IAteIt/Network/FirebaseTestView.swift
+++ b/IAteIt/IAteIt/Network/FirebaseTestView.swift
@@ -82,7 +82,7 @@ struct FirebaseTestView: View {
                 // meal에 caption 추가/수정
                 Button(action: {
                     let caption = "맥모닝 맛있다"
-                    FirebaseConnector().setMealCaption(mealId: "testMealId1", caption: caption)
+//                    FirebaseConnector().setMealCaption(mealId: "testMealId1", caption: caption)
                 }, label: {
                     Text("Caption")
                 })
@@ -90,7 +90,7 @@ struct FirebaseTestView: View {
                 // meal에 location 추가/수정
                 Button(action: {
                     let location = "맥도날드"
-                    FirebaseConnector().setMealLocation(mealId: "testMealId1", location: location)
+//                    FirebaseConnector().setMealLocation(mealId: "testMealId1", location: location)
                 }, label: {
                     Text("Location")
                 })

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -63,6 +63,6 @@ struct FeedHeaderView: View {
 
 struct FeedHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        FeedView(cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -63,6 +63,6 @@ struct FeedHeaderView: View {
 
 struct FeedHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        FeedView(cameraViewModel: CameraViewModel())
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -12,51 +12,50 @@ struct FeedHeaderView: View {
     let profilePicSize: CGFloat = 36
     
     var meal: Meal
+    var user: User
     
     var body: some View {
         VStack {
             HStack(alignment: .center, spacing: 12) {
-                if let indexOfUser = feedMeals.userList.firstIndex(where: { $0.id == meal.userId }) {
-                    ZStack {
-                        if let userImage = feedMeals.userList[indexOfUser].profileImageUrl {
-                            Rectangle()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: profilePicSize, height: profilePicSize)
-                            AsyncImage(url: URL(string: userImage)) { image in
-                                image
-                                    .resizable()
-                                    .scaledToFill()
-                                    .layoutPriority(-1)
-                            } placeholder: {
-                                Color(UIColor.systemGray5)
-                            }
+                ZStack {
+                    if let userImage = user.profileImageUrl {
+                        Rectangle()
+                            .aspectRatio(contentMode: .fit)
                             .frame(width: profilePicSize, height: profilePicSize)
-                        } else {
-                            Image(systemName: "person.crop.circle")
+                        AsyncImage(url: URL(string: userImage)) { image in
+                            image
                                 .resizable()
-                                .frame(width: profilePicSize, height: profilePicSize)
-                                .foregroundColor(Color(UIColor.systemGray3))
+                                .scaledToFill()
+                                .layoutPriority(-1)
+                        } placeholder: {
+                            Color(UIColor.systemGray5)
                         }
+                        .frame(width: profilePicSize, height: profilePicSize)
+                    } else {
+                        Image(systemName: "person.crop.circle")
+                            .resizable()
+                            .frame(width: profilePicSize, height: profilePicSize)
+                            .foregroundColor(Color(UIColor.systemGray3))
                     }
-                    .clipped()
-                    .cornerRadius(profilePicSize/2)
-                    .padding([.top], 3)
-                    
-                    VStack(alignment: .leading) {
-                        Text(feedMeals.userList[indexOfUser].nickname)
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                        
-                        if let location = meal.location {
-                            Text("\(location) • \(meal.uploadDate.timeAgoDisplay())")
-                                .font(.footnote)
-                        } else {
-                            Text(meal.uploadDate.timeAgoDisplay())
-                                .font(.footnote)
-                        }
-                    }
-                    Spacer()
                 }
+                .clipped()
+                .cornerRadius(profilePicSize/2)
+                .padding([.top], 3)
+                
+                VStack(alignment: .leading) {
+                    Text(user.nickname)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                    
+                    if let location = meal.location {
+                        Text("\(location) • \(meal.uploadDate.timeAgoDisplay())")
+                            .font(.footnote)
+                    } else {
+                        Text(meal.uploadDate.timeAgoDisplay())
+                            .font(.footnote)
+                    }
+                }
+                Spacer()
             }
         }
     }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -10,6 +10,7 @@ import Firebase
 import FirebaseFirestore
 
 struct FeedView: View {
+    @StateObject var cameraViewModel = CameraViewModel()
     @ObservedObject var loginState: LoginStateModel
     @ObservedObject var feedMeals: FeedMealModel
     @State private var isCameraViewPresented = false
@@ -18,6 +19,7 @@ struct FeedView: View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 27) {
                 Button(action: {
+                    cameraViewModel.type = .newMeal
                     isCameraViewPresented.toggle()
                 }, label: {
                     AddMealView()
@@ -26,14 +28,14 @@ struct FeedView: View {
                 })
                 .tint(.black)
                 .fullScreenCover(isPresented: $isCameraViewPresented, content: {
-                    CameraView(loginState: loginState, feedMeals: feedMeals)
+                    CameraView(loginState: loginState, feedMeals: feedMeals, viewModel: cameraViewModel)
                 })
                 ForEach(feedMeals.mealList, id: \.self) { eachMeal in
                     if let indexOfUser = feedMeals.userList.firstIndex(where: { $0.id == eachMeal.userId }) {
                         VStack(spacing: 8) {
                             FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: feedMeals.userList[indexOfUser])
                                 .padding(.horizontal, .paddingHorizontal)
-                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
+                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), cameraViewModel: cameraViewModel, loginState: loginState, feedMeals: feedMeals, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
                                 TabView {
                                     ForEach(eachMeal.plates, id: \.self) { plate in
                                         PhotoCardView(plate: plate)
@@ -44,7 +46,7 @@ struct FeedView: View {
                             .buttonStyle(PlainButtonStyle())
                             .frame(minHeight: 358)
                             .tabViewStyle(.page)
-                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
+                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), cameraViewModel: cameraViewModel, loginState: loginState, feedMeals: feedMeals, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
                                 //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
                                 FeedFooterView(meal: eachMeal)
                                     .padding(.horizontal, .paddingHorizontal)
@@ -78,6 +80,6 @@ struct FeedView: View {
 
 struct FeedView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        FeedView(cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -29,26 +29,28 @@ struct FeedView: View {
                     CameraView(loginState: loginState, feedMeals: feedMeals)
                 })
                 ForEach(feedMeals.mealList, id: \.self) { eachMeal in
-                    VStack(spacing: 8) {
-                        FeedHeaderView(feedMeals: feedMeals, meal: eachMeal)
-                            .padding(.horizontal, .paddingHorizontal)
-                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[index])) {
-                            TabView {
-                                ForEach(eachMeal.plates, id: \.self) { plate in
-                                    PhotoCardView(plate: plate)
-                                        .padding(.horizontal, .paddingHorizontal)
+                    if let indexOfUser = feedMeals.userList.firstIndex(where: { $0.id == eachMeal.userId }) {
+                        VStack(spacing: 8) {
+                            FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: feedMeals.userList[indexOfUser])
+                                .padding(.horizontal, .paddingHorizontal)
+                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
+                                TabView {
+                                    ForEach(eachMeal.plates, id: \.self) { plate in
+                                        PhotoCardView(plate: plate)
+                                            .padding(.horizontal, .paddingHorizontal)
+                                    }
                                 }
                             }
+                            .buttonStyle(PlainButtonStyle())
+                            .frame(minHeight: 358)
+                            .tabViewStyle(.page)
+                            NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[indexOfUser])) {
+                                //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
+                                FeedFooterView(meal: eachMeal)
+                                    .padding(.horizontal, .paddingHorizontal)
+                            }
+                            .buttonStyle(PlainButtonStyle())
                         }
-                        .buttonStyle(PlainButtonStyle())
-                        .frame(minHeight: 358)
-                        .tabViewStyle(.page)
-                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[index])) {
-                            //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
-                            FeedFooterView(meal: eachMeal)
-                                .padding(.horizontal, .paddingHorizontal)
-                        }
-                        .buttonStyle(PlainButtonStyle())
                     }
                 }
             }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -11,8 +11,8 @@ import FirebaseFirestore
 
 struct FeedView: View {
     @StateObject var cameraViewModel = CameraViewModel()
-    @ObservedObject var loginState: LoginStateModel
-    @ObservedObject var feedMeals: FeedMealModel
+    @EnvironmentObject var loginState: LoginStateModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isCameraViewPresented = false
     
     var body: some View {
@@ -28,7 +28,7 @@ struct FeedView: View {
                 })
                 .tint(.black)
                 .fullScreenCover(isPresented: $isCameraViewPresented, content: {
-                    CameraView(loginState: loginState, feedMeals: feedMeals, viewModel: cameraViewModel)
+                    CameraView(viewModel: cameraViewModel)
                 })
                 switch feedMeals.mealList.count != 0 {
                 case true:
@@ -37,7 +37,11 @@ struct FeedView: View {
                             VStack(spacing: 8) {
                                 FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: user)
                                     .padding(.horizontal, .paddingHorizontal)
-                                NavigationLink(destination: MealDetailView(commentBar: CommentBar(), cameraViewModel: cameraViewModel, loginState: loginState, feedMeals: feedMeals, meal: eachMeal, user: user)) {
+                                NavigationLink(destination: MealDetailView(meal: eachMeal, user: user)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
                                     TabView {
                                         ForEach(eachMeal.plates, id: \.self) { plate in
                                             PhotoCardView(plate: plate)
@@ -48,7 +52,11 @@ struct FeedView: View {
                                 .buttonStyle(PlainButtonStyle())
                                 .frame(minHeight: 358)
                                 .tabViewStyle(.page)
-                                NavigationLink(destination: MealDetailView(commentBar: CommentBar(), cameraViewModel: cameraViewModel, loginState: loginState, feedMeals: feedMeals, meal: eachMeal, user: user)) {
+                                NavigationLink(destination: MealDetailView(meal: eachMeal, user: user)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
                                     //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
                                     FeedFooterView(meal: eachMeal)
                                         .padding(.horizontal, .paddingHorizontal)
@@ -87,6 +95,6 @@ struct FeedView: View {
 
 struct FeedView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        FeedView(cameraViewModel: CameraViewModel())
     }
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -31,9 +31,9 @@ struct FeedView: View {
                     CameraView(loginState: loginState, feedMeals: feedMeals, viewModel: cameraViewModel)
                 })
                 ForEach(feedMeals.mealList, id: \.self) { eachMeal in
-                    if let indexOfUser = feedMeals.userList.firstIndex(where: { $0.id == eachMeal.userId }) {
+                    if let user = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
                         VStack(spacing: 8) {
-                            FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: feedMeals.userList[indexOfUser])
+                            FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: user)
                                 .padding(.horizontal, .paddingHorizontal)
                             NavigationLink(destination: MealDetailView(commentBar: CommentBar(), cameraViewModel: cameraViewModel, loginState: loginState, feedMeals: feedMeals, meal: eachMeal, user: user)) {
                                 TabView {

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -32,7 +32,7 @@ struct FeedView: View {
                     VStack(spacing: 8) {
                         FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, index: index)
                             .padding(.horizontal, .paddingHorizontal)
-                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), meal: eachMeal)) {
+                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[index])) {
                             TabView {
                                 ForEach(eachMeal.plates, id: \.self) { plate in
                                     PhotoCardView(plate: plate)
@@ -43,7 +43,7 @@ struct FeedView: View {
                         .buttonStyle(PlainButtonStyle())
                         .frame(minHeight: 358)
                         .tabViewStyle(.page)
-                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), meal: eachMeal)) {
+                        NavigationLink(destination: MealDetailView(commentBar: CommentBar(), loginState: loginState, meal: eachMeal, user: feedMeals.userList[index])) {
                             //위 링크랑 다르게, 비리얼처럼 댓글창에 포커싱되어서 넘어가는 건 어떨지 해서 분리
                             FeedFooterView(meal: eachMeal)
                                 .padding(.horizontal, .paddingHorizontal)

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -54,4 +54,29 @@ final class FeedMealModel: ObservableObject {
         }
     }
     
+    func saveCaption(meal: Meal, content: String) {
+        Task {
+            await FirebaseConnector.shared.setMealCaption(mealId: meal.id!, caption: content)
+            mealList.indices.forEach { index in
+                if mealList[index].id == meal.id {
+                    DispatchQueue.main.async {
+                        self.mealList[index].caption = content
+                    }
+                }
+            }
+        }
+    }
+    
+    func saveLocation(meal: Meal, content: String) {
+        Task {
+            await FirebaseConnector.shared.setMealLocation(mealId: meal.id!, location: content)
+            mealList.indices.forEach { index in
+                if mealList[index].id == meal.id {
+                    DispatchQueue.main.async {
+                        self.mealList[index].location = content
+                    }
+                }
+            }
+        }
+    }
 }

--- a/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
@@ -39,8 +39,13 @@ struct AddCommentBarView: View {
                         }
                     Spacer()
                     Button(action: {
-                        // TODO: commentBar.type에 따라 commentBar.input을 코멘트/캡션/장소에 저장
-                        feedMeals.commentUpload(meal: meal, comment: commentBar.input)
+                        if commentBar.type == .comment {
+                            feedMeals.commentUpload(meal: meal, comment: commentBar.input)
+                        } else if commentBar.type == .caption {
+                            feedMeals.saveCaption(meal: meal, content: commentBar.input)
+                        } else if commentBar.type == .location {
+                            feedMeals.saveLocation(meal: meal, content: commentBar.input)
+                        }
                         isFocused = false
                         commentBar.input = ""
                     }, label: {

--- a/IAteIt/IAteIt/View/MealDetail/Component/AddPlateButtonView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/AddPlateButtonView.swift
@@ -1,0 +1,39 @@
+//
+//  AddPlateButtonView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/05/11.
+//
+
+import SwiftUI
+
+struct AddPlateButtonView: View {
+    var body: some View {
+        HStack {
+            Spacer()
+            Button(action: {
+                
+            }, label: {
+                HStack {
+                    Image(systemName: "camera.fill")
+                    Text("Add a plate")
+                        .fontWeight(.semibold)
+                }
+                .font(.subheadline)
+                .foregroundColor(.white)
+                .padding(EdgeInsets(top: 6, leading: 13, bottom: 6, trailing: 13))
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .foregroundColor(.black)
+                )
+            })
+        }
+        .padding(.horizontal, .paddingHorizontal)
+    }
+}
+
+struct AddPlateButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddPlateButtonView()
+    }
+}

--- a/IAteIt/IAteIt/View/MealDetail/Component/AddPlateButtonView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/AddPlateButtonView.swift
@@ -8,27 +8,20 @@
 import SwiftUI
 
 struct AddPlateButtonView: View {
+    
     var body: some View {
         HStack {
-            Spacer()
-            Button(action: {
-                
-            }, label: {
-                HStack {
-                    Image(systemName: "camera.fill")
-                    Text("Add a plate")
-                        .fontWeight(.semibold)
-                }
-                .font(.subheadline)
-                .foregroundColor(.white)
-                .padding(EdgeInsets(top: 6, leading: 13, bottom: 6, trailing: 13))
-                .background(
-                    RoundedRectangle(cornerRadius: 20)
-                        .foregroundColor(.black)
-                )
-            })
+            Image(systemName: "camera.fill")
+            Text("Add a plate")
+                .fontWeight(.semibold)
         }
-        .padding(.horizontal, .paddingHorizontal)
+        .font(.subheadline)
+        .foregroundColor(.white)
+        .padding(EdgeInsets(top: 6, leading: 13, bottom: 6, trailing: 13))
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .foregroundColor(.black)
+        )
     }
 }
 

--- a/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/MealDetailTopView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MealDetailTopView: View {
     @ObservedObject var commentBar: CommentBar
+    @Binding var isMyMeal: Bool
     
     var meal: Meal
     
@@ -20,25 +21,50 @@ struct MealDetailTopView: View {
                     .font(.footnote)
                     .foregroundColor(Color(UIColor.systemGray))
             }
-            Button(action: {
-                // TODO: CommentBar에 focus
-                commentBar.type = .caption
-                commentBar.input = meal.caption ?? ""
-            }, label: {
+            if isMyMeal {
+                Button(action: {
+                    commentBar.type = .caption
+                    commentBar.input = meal.caption ?? ""
+                }, label: {
+                    if let caption = meal.caption {
+                        Text(caption)
+                            .font(.headline)
+                            .foregroundColor(.black)
+                    } else {
+                        Text("Add a caption")
+                            .font(.headline)
+                            .foregroundColor(Color(.systemGray3))
+                    }
+                })
+            } else {
                 if let caption = meal.caption {
                     Text(caption)
                         .font(.headline)
                         .foregroundColor(.black)
-                } else {
-                    Text("Add a caption")
-                        .font(.headline)
-                        .foregroundColor(Color(.systemGray3))
                 }
-            })
-            Button(action: {
-                commentBar.type = .location
-                commentBar.input = meal.location ?? ""
-            }, label: {
+            }
+            if isMyMeal {
+                Button(action: {
+                    commentBar.type = .location
+                    commentBar.input = meal.location ?? ""
+                }, label: {
+                    if let location = meal.location {
+                        HStack(alignment: .center, spacing: 4) {
+                            Image(systemName: "location.fill")
+                            Text(location)
+                        }
+                        .font(.subheadline)
+                        .foregroundColor(.black)
+                    } else {
+                        HStack(alignment: .center, spacing: 4) {
+                            Image(systemName: "location.fill")
+                            Text("Add location")
+                        }
+                        .font(.footnote)
+                        .foregroundColor(Color(.systemGray3))
+                    }
+                })
+            } else {
                 if let location = meal.location {
                     HStack(alignment: .center, spacing: 4) {
                         Image(systemName: "location.fill")
@@ -46,21 +72,8 @@ struct MealDetailTopView: View {
                     }
                     .font(.subheadline)
                     .foregroundColor(.black)
-                } else {
-                    HStack(alignment: .center, spacing: 4) {
-                        Image(systemName: "location.fill")
-                        Text("Add location")
-                    }
-                    .font(.footnote)
-                    .foregroundColor(Color(.systemGray3))
                 }
-            })
+            }
         }
-    }
-}
-
-struct MealDetailTopView_Previews: PreviewProvider {
-    static var previews: some View {
-        MealDetailTopView(commentBar: CommentBar(), meal: Meal.meals[1])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct MealDetailView: View {
-    @StateObject var commentBar: CommentBar
-    @StateObject var cameraViewModel: CameraViewModel
-    @ObservedObject var loginState: LoginStateModel
-    @ObservedObject var feedMeals: FeedMealModel
+    @StateObject var commentBar = CommentBar()
+    @EnvironmentObject var cameraViewModel: CameraViewModel
+    @EnvironmentObject var loginState: LoginStateModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @State private var navTitleText = ""
     @State private var isMyMeal = false
     @State private var isCameraViewPresented = false
@@ -47,7 +47,9 @@ struct MealDetailView: View {
                         }
                         .padding(.horizontal, .paddingHorizontal)
                         .fullScreenCover(isPresented: $isCameraViewPresented, content: {
-                            CameraView(loginState: loginState, feedMeals: feedMeals, viewModel: cameraViewModel, mealAddPlateTo: meal)
+                            CameraView(viewModel: cameraViewModel, mealAddPlateTo: meal)
+                                .environmentObject(loginState)
+                                .environmentObject(feedMeals)
                         })
                     }
                     
@@ -96,6 +98,6 @@ extension MealDetailView {
 
 struct MealDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailView(commentBar: CommentBar(), cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel(), meal: Meal.meals[2], user: User.users[0])
+        MealDetailView(commentBar: CommentBar(), meal: Meal.meals[2], user: User.users[0])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -51,11 +51,11 @@ struct MealDetailView: View {
                         })
                     }
                     
-                    if let targetMeal = feedMeals.mealList.first { $0.id == meal.id }  {
+                    if let targetMeal = feedMeals.mealList.first(where: { $0.id == meal.id })  {
                         if let comments = targetMeal.comments {
                             VStack(alignment: .leading, spacing: 12) {
                                 ForEach(comments, id: \.self) { comment in
-                                    if let user = feedMeals.allUsers.first { $0.id == comment.userId } {
+                                    if let user = feedMeals.allUsers.first(where: { $0.id == comment.userId }) {
                                         CommentView(user: user, comment: comment)
                                     } else {
                                         Text("Comment Error")

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 struct MealDetailView: View {
     @StateObject var commentBar: CommentBar
+    @StateObject var cameraViewModel: CameraViewModel
     @ObservedObject var loginState: LoginStateModel
+    @ObservedObject var feedMeals: FeedMealModel
     @State private var navTitleText = ""
     @State private var isMyMeal = false
+    @State private var isCameraViewPresented = false
     
     var meal: Meal
     var user: User
@@ -33,7 +36,19 @@ struct MealDetailView: View {
                     .tabViewStyle(.page)
                     
                     if isMyMeal {
-                        AddPlateButtonView()
+                        HStack {
+                            Spacer()
+                            Button(action: {
+                                cameraViewModel.type = .addPlate
+                                isCameraViewPresented.toggle()
+                            }, label: {
+                                AddPlateButtonView()
+                            })
+                        }
+                        .padding(.horizontal, .paddingHorizontal)
+                        .fullScreenCover(isPresented: $isCameraViewPresented, content: {
+                            CameraView(loginState: loginState, feedMeals: feedMeals, viewModel: cameraViewModel, mealAddPlateTo: meal)
+                        })
                     }
                     
                     if let comments = meal.comments {
@@ -75,6 +90,6 @@ extension MealDetailView {
 
 struct MealDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailView(commentBar: CommentBar(), loginState: LoginStateModel(), meal: Meal.meals[2], user: User.users[0])
+        MealDetailView(commentBar: CommentBar(), cameraViewModel: CameraViewModel(), loginState: LoginStateModel(), feedMeals: FeedMealModel(), meal: Meal.meals[2], user: User.users[0])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -23,7 +23,7 @@ struct MealDetailView: View {
         ZStack {
             ScrollView {
                 VStack {
-                    MealDetailTopView(commentBar: commentBar, meal: meal)
+                    MealDetailTopView(commentBar: commentBar, isMyMeal: $isMyMeal, meal: meal)
                         .padding(.horizontal, .paddingHorizontal)
                     
                     TabView {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -11,6 +11,7 @@ struct MealDetailView: View {
     @StateObject var commentBar: CommentBar
     @ObservedObject var loginState: LoginStateModel
     @State private var navTitleText = ""
+    @State private var isMyMeal = false
     
     var meal: Meal
     var user: User
@@ -30,6 +31,10 @@ struct MealDetailView: View {
                     }
                     .frame(minHeight: 358)
                     .tabViewStyle(.page)
+                    
+                    if isMyMeal {
+                        AddPlateButtonView()
+                    }
                     
                     if let comments = meal.comments {
                         VStack(alignment: .leading, spacing: 12) {
@@ -51,16 +56,18 @@ struct MealDetailView: View {
             self.hideKeyboard()
         }
         .onAppear {
-            setNavigationTitleText()
+            configMyMealUI()
         }
     }
 }
 
 extension MealDetailView {
-    func setNavigationTitleText() {
+    func configMyMealUI() {
         if loginState.user?.id == user.id {
+            isMyMeal = true
             navTitleText = "I ate it."
         } else {
+            isMyMeal = false
             navTitleText = "\(user.nickname) ate it."
         }
     }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -9,8 +9,11 @@ import SwiftUI
 
 struct MealDetailView: View {
     @StateObject var commentBar: CommentBar
+    @ObservedObject var loginState: LoginStateModel
+    @State private var navTitleText = ""
     
     var meal: Meal
+    var user: User
     
     var body: some View {
         ZStack {
@@ -43,14 +46,28 @@ struct MealDetailView: View {
                 .padding([.bottom], 10)
                 .padding(.horizontal, .paddingHorizontal)
         }
+        .navigationTitle(navTitleText)
         .onTapGesture {
             self.hideKeyboard()
+        }
+        .onAppear {
+            setNavigationTitleText()
+        }
+    }
+}
+
+extension MealDetailView {
+    func setNavigationTitleText() {
+        if loginState.user?.id == user.id {
+            navTitleText = "I ate it."
+        } else {
+            navTitleText = "\(user.nickname) ate it."
         }
     }
 }
 
 struct MealDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailView(commentBar: CommentBar(), meal: Meal.meals[2])
+        MealDetailView(commentBar: CommentBar(), loginState: LoginStateModel(), meal: Meal.meals[2], user: User.users[0])
     }
 }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -83,7 +83,7 @@ struct CameraView: View {
                                 .font(.subheadline)
                             }
                         }
-                        .offset(y: -200)
+                        .offset(y: -290)
                     }
                 
                 

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -10,8 +10,8 @@ import AVFoundation
 
 struct CameraView: View {
     @Environment(\.dismiss) var dismiss
-    @ObservedObject var loginState: LoginStateModel
-    @ObservedObject var feedMeals: FeedMealModel
+    @EnvironmentObject var loginState: LoginStateModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @ObservedObject var viewModel: CameraViewModel
     @ObservedObject var model = Camera()
     
@@ -186,6 +186,6 @@ extension CameraView {
 
 struct CameraView_Previews: PreviewProvider {
     static var previews: some View {
-        CameraView(loginState: LoginStateModel(), feedMeals: FeedMealModel(), viewModel: CameraViewModel())
+        CameraView(viewModel: CameraViewModel())
     }
 }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -29,7 +29,6 @@ struct CameraView: View {
         VStack {
             HStack {
                 Button(action: {
-                    viewModel.isTaken = false
                     dismiss()
                 }, label: {
                     Image(systemName: "multiply")

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -74,7 +74,7 @@ class CameraViewModel: ObservableObject {
         }
         
         DispatchQueue.main.async {
-            withAnimation{self.isTaken = true}
+            withAnimation{self.isTaken.toggle()}
         }
         
     }
@@ -85,7 +85,7 @@ class CameraViewModel: ObservableObject {
             self.session.startRunning()
             
             DispatchQueue.main.async {
-                withAnimation{self.isTaken = false}
+                withAnimation{self.isTaken.toggle()}
                 
                 self.isSaved = false
             }

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -18,6 +18,21 @@ class CameraViewModel: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
     var imageToBeUploaded: UIImage?
     
+    enum types {
+        case newMeal
+        case addPlate
+        
+        func setButtonText() -> String {
+            switch self {
+            case .newMeal:
+                return "Upload"
+            case .addPlate:
+                return "Add"
+            }
+        }
+    }
+
+    @Published var type = types.newMeal
     @Published var isTaken = false
     @Published var shutterEffect = false
     @Published var isSaved = false
@@ -59,7 +74,7 @@ class CameraViewModel: ObservableObject {
         }
         
         DispatchQueue.main.async {
-            withAnimation{self.isTaken.toggle()}
+            withAnimation{self.isTaken = true}
         }
         
     }
@@ -70,7 +85,7 @@ class CameraViewModel: ObservableObject {
             self.session.startRunning()
             
             DispatchQueue.main.async {
-                withAnimation{self.isTaken.toggle()}
+                withAnimation{self.isTaken = false}
                 
                 self.isSaved = false
             }


### PR DESCRIPTION
## 관련 이슈들
- #44 

## 작업 내용
- 내가 올린 meal인 경우 caption/location 입력, plate 사진 추가가 가능하도록 했습니다.
- mealDetailView의 navigationTitle에 올린 사람의 username이 보입니다. ("\(username) ate it.", 내가 올린 경우 I ate it)

## 리뷰 노트
### Add a plate
- 빠른 기능 구현을 위해 add a plate 버튼은 단순 버튼으로 구현했습니다. (pull to add 적용안함..)
- commentBar를 캡션, 장소입력과 같이 쓰는 것과 유사하게, CameraViewModel의 type에 따라 CameraView가 새로운 meal을 생성하거나 plate를 추가하는 뷰가 되도록 했습니다.
### caption, location
- comment 저장 코드를 참고하여 유사하게 작성했습니다.
- 현재 plate 추가, caption/location 저장, comment 추가하면 모두 feedView로 튕겨나가는 것 같네요..

## 스크린샷(UX의 경우 gif)
<p list="left">
<img src="https://github.com/Bnomad-space/IAteIt/assets/103012157/0e5c4b33-8acd-426b-b317-d8d629bbb8cb" width="250">
<img src="https://github.com/Bnomad-space/IAteIt/assets/103012157/1ef0c616-f274-427d-aaf7-8e7c803ac235" width="250">
<img src="https://github.com/Bnomad-space/IAteIt/assets/103012157/62190501-a2d3-48fb-81bb-14e8600a6ce1" width="250">
</p>

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
