### PR TITLE
[Feat] #55 UploadView 카메라 관련 오류 수정

### DIFF
--- a/IAteIt/IAteIt/View/Upload/Camera.swift
+++ b/IAteIt/IAteIt/View/Upload/Camera.swift
@@ -102,7 +102,7 @@ class Camera: NSObject, ObservableObject {
         capsuleView.layer.cornerRadius = 38
         
         let timeLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 170, height: 80))
-//        timeLabel.text = Date().toTimeString()
+        timeLabel.text = Date().toTimeString()
         timeLabel.font = UIFont.systemFont(ofSize: 38)
         timeLabel.textColor = .white
         timeLabel.textAlignment = .center

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -22,7 +22,7 @@ struct CameraView: View {
     }()
     
     @State var currentTime = Date()
-    @State private var isButtonDisabled = false
+    @State private var isTaken: Bool = false
     
     var body: some View {
         VStack {
@@ -115,19 +115,16 @@ struct CameraView: View {
                 } else {
                     VStack {
                         Spacer()
-
+                        
                         Button(action: {
-                            if !isButtonDisabled {
                             viewModel.capturePhoto()
-                                isButtonDisabled = true
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                                    isButtonDisabled = false }
-                                }}, label: {
+                            self.isTaken.toggle()
+                        }, label: {
                             Circle()
                                 .stroke(.black,lineWidth: 4)
                                 .frame(width: 72, height: 72)
                                 .padding(.bottom, 85)
-                        })
+                        }) .disabled(isTaken)
                     }
                 }
             }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -22,6 +22,7 @@ struct CameraView: View {
     }()
     
     @State var currentTime = Date()
+    @State private var isButtonDisabled = false
     
     var body: some View {
         VStack {
@@ -114,8 +115,14 @@ struct CameraView: View {
                 } else {
                     VStack {
                         Spacer()
-                        
-                        Button(action: {viewModel.capturePhoto()}, label: {
+
+                        Button(action: {
+                            if !isButtonDisabled {
+                            viewModel.capturePhoto()
+                                isButtonDisabled = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                                    isButtonDisabled = false }
+                                }}, label: {
                             Circle()
                                 .stroke(.black,lineWidth: 4)
                                 .frame(width: 72, height: 72)

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -27,6 +27,7 @@ struct CameraView: View {
         VStack {
             HStack {
                 Button(action: {
+                    viewModel.stopCamera()
                     dismiss()
                 }, label: {
                     Image(systemName: "multiply")

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -83,4 +83,8 @@ class CameraViewModel: ObservableObject {
         let overlayImage = model.timestampOverlay(image: croppedImage)
         model.savePhoto(image: overlayImage)
     }
+    
+    func stopCamera() {
+        model.session.stopRunning()
+    }
 }


### PR DESCRIPTION
## 관련 이슈들
- #55 

## 작업 내용
- 로컬에 저장되는 사진에 타임 스탬프 표시 ( 주석처리되어있었습니다..)

- 카메라 종료 버튼 눌렀을 때 카메라세션이 종료되지 않아 우측 상단 초록색 표시등이 꺼지지 않던 문제를 해결했습니다. 이제 X버튼을 누르면 카메라 프리뷰가 종료됨과 동시에 카메라 세션이 종료됩니다.

- 캡쳐(셔터) 버튼을 누르면 업로드, 리테이크 버튼이 나오면서 캡쳐가 되었는데 여러번 누르면 캡쳐가 되면서 업로드, 리테이크 버튼이 나왔다가 사라지고 다시 캡쳐버튼이 나오는 문제를 해결했습니다. 

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)

https://github.com/Bnomad-space/IAteIt/assets/103012086/1753cca2-eceb-4edd-9f1e-82216accccf0


## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
