### PR TITLE
[feat] 캡쳐버튼 관련 오류 수정

### DIFF
--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -19,6 +19,7 @@ struct FeedView: View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 27) {
                 Button(action: {
+                    cameraViewModel.reset()
                     cameraViewModel.type = .newMeal
                     isCameraViewPresented.toggle()
                 }, label: {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -39,6 +39,7 @@ struct MealDetailView: View {
                         HStack {
                             Spacer()
                             Button(action: {
+                                cameraViewModel.reset()
                                 cameraViewModel.type = .addPlate
                                 isCameraViewPresented.toggle()
                             }, label: {

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -24,7 +24,7 @@ struct CameraView: View {
     }()
     
     @State var currentTime = Date()
-    @State private var isTaken: Bool = false
+    @State private var isButtonDisabled = false
     
     var body: some View {
         VStack {
@@ -69,7 +69,7 @@ struct CameraView: View {
                                     .foregroundColor(.white)
                             )
                             .padding(EdgeInsets(top: -230, leading: 290, bottom: 0, trailing: 0)))
-                    // TODO: 기존 meal 포스팅의 캡션, 장소 위치잡기
+                // TODO: 기존 meal 포스팅의 캡션, 장소 위치잡기
                     .overlay {
                         VStack(alignment: .center, spacing: 6) {
                             if let caption = mealAddPlateTo?.caption {
@@ -139,14 +139,19 @@ struct CameraView: View {
                         Spacer()
                         
                         Button(action: {
-                            viewModel.capturePhoto()
-                            self.isTaken.toggle()
+                            if !isButtonDisabled {
+                                viewModel.capturePhoto()
+                                isButtonDisabled = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                                    isButtonDisabled = false
+                                }
+                            }
                         }, label: {
                             Circle()
                                 .stroke(.black,lineWidth: 4)
                                 .frame(width: 72, height: 72)
                                 .padding(.bottom, 85)
-                        }) .disabled(isTaken)
+                        })
                     }
                 }
             }

--- a/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraViewModel.swift
@@ -102,4 +102,10 @@ class CameraViewModel: ObservableObject {
     func stopCamera() {
         model.session.stopRunning()
     }
+    
+    func reset() {
+        isTaken = false
+        imageToBeUploaded = nil
+        configure()
+    }
 }


### PR DESCRIPTION
- 캡쳐 한 상태에서 다시 카메라 프리뷰로 진입하면 업로드, 리테이크 버튼이 먼저 보이는 문제 해결
- 캡쳐하고 다시 프리뷰  진입하면 캡쳐 버튼 안눌리는 문제 해결

## 관련 이슈들
- #57 

## 작업 내용
- 캡쳐버튼 누른 후 생기던 문제 해결
1. 캡쳐 후 upload, retake 버튼 나온 상태에서 나간 후  addPlate, what are you eating now 버튼 눌러서 다시 카메라 프리뷰 진입하면 캡쳐버튼이 아닌 업로드 리테이크 버튼이 보이는 문제 해결
2. 캡쳐 후 retake를 누르거나 나갔다 다시 프리뷰로 진입하면 캡쳐버튼 안눌리던 문제가 생겨 캡쳐버튼 코드 원복

## 리뷰 노트
- 리뷰를 받고 싶은 포인트, 고민한 점들을 적어주세요.

## 스크린샷(UX의 경우 gif)
<img src="https://이미지링크를넣어주세요" width="300">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
