### PR TITLE
[Feat] #58 meal, plate 삭제 기능

### DIFF
--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -110,4 +110,24 @@ extension FirebaseConnector {
         }
         return meals
     }
+    
+    // plate 이미지 서버에서 삭제
+    func deletePlateImage(plateId: String) async throws {
+        let storageRef = Storage.storage().reference()
+        let imageRef = storageRef.child("plateImage/\(plateId)")
+        
+        try await imageRef.delete()
+    }
+    
+    // 특정 meal 삭제
+    func deleteMeal(mealId: String) async throws {
+        try await FirebaseConnector.meals.document(mealId).delete()
+    }
+    
+    // 특정 plate 삭제
+    func deletePlate(mealId: String, plate: Plate) async throws {
+        try await FirebaseConnector.meals.document(mealId).updateData([
+            "plates": FieldValue.arrayRemove([plate.firebaseData])
+        ])
+    }
 }

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -14,7 +14,7 @@ extension FirebaseConnector {
     static let meals = Firestore.firestore().collection("meals")
     
     // 새로운 meal 생성 (첫번째 plate 생성 포함, 캡션, 장소 없는 상태)
-    func setNewMeal(meal: Meal) async throws {
+    func setNewMeal(meal: Meal) async throws -> String {
         let document = FirebaseConnector.meals.document()
         let documentId = document.documentID
         var plate = meal.plates[0]
@@ -27,6 +27,7 @@ extension FirebaseConnector {
         try await FirebaseConnector.meals.document(documentId).updateData([
             "plates": FieldValue.arrayUnion([plate.firebaseData])
         ])
+        return documentId
     }
     
     // 특정 meal에 새로운 plate 추가

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -85,8 +85,9 @@ final class FeedMealModel: ObservableObject {
         }
     }
     
-    func deletePlate(mealId: String, plate: Plate) {
+    func deletePlate(meal: Meal, plate: Plate) {
         Task {
+            guard let mealId = meal.id else { return }
             try await FirebaseConnector.shared.deletePlate(mealId: mealId, plate: plate)
             try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
             DispatchQueue.main.async {
@@ -97,8 +98,9 @@ final class FeedMealModel: ObservableObject {
         }
     }
     
-    func deleteMeal(mealId: String) {
+    func deleteMeal(meal: Meal) {
         Task {
+            guard let mealId = meal.id else { return }
             try await FirebaseConnector.shared.deleteMeal(mealId: mealId)
             if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
                 for plate in self.mealList[index].plates {

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -80,4 +80,30 @@ final class FeedMealModel: ObservableObject {
             }
         }
     }
+    
+    func deletePlate(mealId: String, plate: Plate) {
+        Task {
+            try await FirebaseConnector.shared.deletePlate(mealId: mealId, plate: plate)
+            try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
+            DispatchQueue.main.async {
+                if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
+                    self.mealList[index].plates.removeAll(where: { $0.id == plate.id })
+                }
+            }
+        }
+    }
+    
+    func deleteMeal(mealId: String) {
+        Task {
+            try await FirebaseConnector.shared.deleteMeal(mealId: mealId)
+            if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
+                for plate in self.mealList[index].plates {
+                    try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
+                }
+            }
+            DispatchQueue.main.async {
+                self.mealList.removeAll(where: { $0.id == mealId })
+            }
+        }
+    }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -33,7 +33,7 @@ struct MealDetailView: View {
                             PhotoCardView(plate: plate)
                                 .padding(.horizontal, .paddingHorizontal)
                                 .contextMenu {
-                                    if isMyMeal {
+                                    if isMyMeal && (meal.plates.count > 1) {
                                         Button(role: .destructive, action: {
                                             isShowingPlateDeleteAlert = true
                                             print(plate)
@@ -44,7 +44,7 @@ struct MealDetailView: View {
                                 }
                                 .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
                                     Button("Delete", role: .destructive, action: {
-                                        feedMeals.deletePlate(mealId: meal.id!, plate: plate)
+                                        feedMeals.deletePlate(meal: meal, plate: plate)
                                     })
                                     Button("Cancel", role: .cancel, action: {})
                                 }, message: {
@@ -98,7 +98,7 @@ struct MealDetailView: View {
         .navigationTitle(navTitleText)
         .alert("Delete this meal", isPresented: $isShowingMealDeleteAlert, actions: {
             Button("Delete", role: .destructive, action: {
-                feedMeals.deleteMeal(mealId: meal.id!)
+                feedMeals.deleteMeal(meal: meal)
             })
             Button("Cancel", role: .cancel, action: {})
         }, message: {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -33,12 +33,14 @@ struct MealDetailView: View {
                             PhotoCardView(plate: plate)
                                 .padding(.horizontal, .paddingHorizontal)
                                 .contextMenu {
-                                    Button(role: .destructive, action: {
-                                        isShowingPlateDeleteAlert = true
-                                        print(plate)
-                                    }, label: {
-                                        Label("Delete this plate", systemImage: "trash")
-                                    })
+                                    if isMyMeal {
+                                        Button(role: .destructive, action: {
+                                            isShowingPlateDeleteAlert = true
+                                            print(plate)
+                                        }, label: {
+                                            Label("Delete this plate", systemImage: "trash")
+                                        })
+                                    }
                                 }
                                 .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
                                     Button("Delete", role: .destructive, action: {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -15,6 +15,8 @@ struct MealDetailView: View {
     @State private var navTitleText = ""
     @State private var isMyMeal = false
     @State private var isCameraViewPresented = false
+    @State private var isShowingMealDeleteAlert = false
+    @State private var isShowingPlateDeleteAlert = false
     
     var meal: Meal
     var user: User
@@ -30,6 +32,22 @@ struct MealDetailView: View {
                         ForEach(meal.plates, id: \.self) { plate in
                             PhotoCardView(plate: plate)
                                 .padding(.horizontal, .paddingHorizontal)
+                                .contextMenu {
+                                    Button(role: .destructive, action: {
+                                        isShowingPlateDeleteAlert = true
+                                        print(plate)
+                                    }, label: {
+                                        Label("Delete this plate", systemImage: "trash")
+                                    })
+                                }
+                                .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
+                                    Button("Delete", role: .destructive, action: {
+                                        // TODO: plate 삭제
+                                    })
+                                    Button("Cancel", role: .cancel, action: {})
+                                }, message: {
+                                    Text("This action is irreversible.")
+                                })
                         }
                     }
                     .frame(minHeight: 358)
@@ -75,6 +93,29 @@ struct MealDetailView: View {
                 .padding(.horizontal, .paddingHorizontal)
         }
         .navigationTitle(navTitleText)
+        .alert("Delete this meal", isPresented: $isShowingMealDeleteAlert, actions: {
+            Button("Delete", role: .destructive, action: {
+                // TODO: meal 삭제
+            })
+            Button("Cancel", role: .cancel, action: {})
+        }, message: {
+            Text("This action is irreversible.")
+        })
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if isMyMeal {
+                    Menu(content: {
+                        Button(role: .destructive, action: {
+                            isShowingMealDeleteAlert = true
+                        }, label: {
+                            Label("Delete this meal", systemImage: "trash")
+                        })
+                    }, label: {
+                        Image(systemName: "ellipsis")
+                    })
+                }
+            }
+        }
         .onTapGesture {
             self.hideKeyboard()
         }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -44,7 +44,7 @@ struct MealDetailView: View {
                                 }
                                 .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
                                     Button("Delete", role: .destructive, action: {
-                                        // TODO: plate 삭제
+                                        feedMeals.deletePlate(mealId: meal.id!, plate: plate)
                                     })
                                     Button("Cancel", role: .cancel, action: {})
                                 }, message: {
@@ -97,7 +97,7 @@ struct MealDetailView: View {
         .navigationTitle(navTitleText)
         .alert("Delete this meal", isPresented: $isShowingMealDeleteAlert, actions: {
             Button("Delete", role: .destructive, action: {
-                // TODO: meal 삭제
+                feedMeals.deleteMeal(mealId: meal.id!)
             })
             Button("Cancel", role: .cancel, action: {})
         }, message: {

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -172,8 +172,10 @@ extension CameraView {
             print(plateImageUrl)
             plate.imageUrl = plateImageUrl
             meal.plates.append(plate)
+            let mealId = try await FirebaseConnector.shared.setNewMeal(meal: meal)
+            meal.id = mealId
+            meal.plates[0].mealId = mealId
             feedMeals.mealList.insert(meal, at: 0)
-            try await FirebaseConnector.shared.setNewMeal(meal: meal)
         }
     }
     func saveAddPlate() {

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -185,8 +185,10 @@ extension CameraView {
         Task {
             let plateImageUrl = try await FirebaseConnector.shared.uploadPlateImage(plateId: plate.id, image: image)
             plate.imageUrl = plateImageUrl
-            if let index = feedMeals.mealList.firstIndex(where: {$0.id == mealId}) {
-                feedMeals.mealList[index].plates.append(plate)
+            DispatchQueue.main.async {
+                if let index = feedMeals.mealList.firstIndex(where: {$0.id == mealId}) {
+                    feedMeals.mealList[index].plates.append(plate)
+                }
             }
             try await FirebaseConnector.shared.addPlateToMeal(mealId: mealId, plate: plate)
         }


### PR DESCRIPTION
## 관련 이슈들
- #58 

## 작업 내용
### Meal, Plate 삭제 기능 구현
- MealDetailView에서 plate 사진 하나를 꾹 누르면 나오는 contextMenu에서 plate 개별 삭제를 할 수 있습니다.
- MealDetailView 네비게이션바 우측 버튼을 누르면 나오는 메뉴에서 해당 Meal을 삭제할 수 있습니다.
### 오류 수정
- meal 생성 후 바로 add plate 해도 서버에 저장되지 않는 문제를 해결했습니다.
- 편의상 FirebaseFirestoreSwift의 기능 사용을 위해 Meal struct의 id를 옵셔널로 해두었는데, meal 생성 후(다시 fetch하기 전에는) meal id가 없어서 생기는 문제(바로 캡션/장소 저장 시 앱 꺼짐)를 해결했습니다.

## 리뷰 노트
- FeedMealModel의 published 값이 바뀌면 FeedView로 이동되는 것일까요ㅜㅜ? meal/plate 삭제도 마찬가지로 feed로 튕겨나가네요..

## 스크린샷(UX의 경우 gif)
### meal 삭제(좌), plate 삭제(우)
<img width="300" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/e47ddd8d-24c8-42cb-b4d6-ef7f795225f8">
<img width="300" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/6f45dfed-24a0-4396-ad2a-2470498ab741">

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
