### PR TITLE
[Feat] #64 프로필 수정 기능

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		630BA6C029AF57BE00019F2E /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6BF29AF57BE00019F2E /* Camera.swift */; };
 		630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6C129AF57F700019F2E /* CameraViewModel.swift */; };
 		6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366BA1D29B613C1004374BE /* CameraPreviewView.swift */; };
+		7E047E4C2A232EC700B29760 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E047E4B2A232EC700B29760 /* Image+Extension.swift */; };
 		7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */; };
 		7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719329A90449005A7B56 /* TempPlate.swift */; };
 		7E2B2DAD29DE9304009EC0ED /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B2DAC29DE9304009EC0ED /* Constants.swift */; };
@@ -82,6 +83,7 @@
 		630BA6BF29AF57BE00019F2E /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		630BA6C129AF57F700019F2E /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
 		6366BA1D29B613C1004374BE /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
+		7E047E4B2A232EC700B29760 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
 		7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentBarView.swift; sourceTree = "<group>"; };
 		7E1F719329A90449005A7B56 /* TempPlate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempPlate.swift; sourceTree = "<group>"; };
 		7E2B2DAC29DE9304009EC0ED /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */,
 				7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */,
 				7EDF91AA29E989BD00FB23A8 /* View+Extension.swift */,
+				7E047E4B2A232EC700B29760 /* Image+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 				7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */,
 				04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */,
 				7E407CD22A0BEBEF001CAFBF /* AddPlateButtonView.swift in Sources */,
+				7E047E4C2A232EC700B29760 /* Image+Extension.swift in Sources */,
 				7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,

--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -96,8 +96,8 @@ final class FirebaseConnector {
     }
     
     // user 정보 업데이트(프로필 수정)
-    func updateUser(user: User) {
-        FirebaseConnector.users.document(user.id)
+    func updateUser(user: User) async throws {
+        try await FirebaseConnector.users.document(user.id)
             .updateData([
             "id": user.id,
             "nickname": user.nickname,
@@ -118,27 +118,15 @@ final class FirebaseConnector {
     }
     
     // user profile 이미지 업로드
-    func uploadProfileImage(userId: String, image: UIImage, completion: @escaping(String) -> Void) {
+    func uploadProfileImage(userId: String, image: UIImage) async throws -> String {
         let storageRef = Storage.storage().reference()
-        let imageRef = storageRef.child("profileImage/\(userId)")
+        let imageRef = storageRef.child("profileImage/\(userId)/")
         guard let imageData = image.jpegData(compressionQuality: 0.1) else {
-            print("DEBUG - fail compression")
-            return
+            throw URLError(.badServerResponse)
         }
-        imageRef.putData(imageData, metadata: nil) { (metadata, error) in
-            if let error = error {
-                print("DEBUG \(error.localizedDescription)")
-                return
-            }
-            imageRef.downloadURL { (url, error) in
-                if let error = error {
-                    print("DEBUG \(error.localizedDescription)")
-                    return
-                }
-                guard let imageUrl = url else { return }
-                
-                completion(imageUrl.absoluteString)
-            }
-        }
+        let returnedMetaData = try await imageRef.putDataAsync(imageData, metadata: nil)
+        let imageUrl: URL = try await imageRef.downloadURL()
+        
+        return imageUrl.absoluteString
     }
 }

--- a/IAteIt/IAteIt/Network/FirebaseTestView.swift
+++ b/IAteIt/IAteIt/Network/FirebaseTestView.swift
@@ -13,23 +13,23 @@ struct FirebaseTestView: View {
         VStack {
             VStack {
                 // 프로필이미지 업로드, 회원가입
-                Button(action: {
-                    var user = User(id: "testUser2Id", nickname: "testUser2Nickname")
-                    let image = UIImage(named: "Sample_Profile2")
-                    if let image = image {
-                        FirebaseConnector().uploadProfileImage(userId: user.id, image: image) { url in
-                            user.profileImageUrl = url
-                            FirebaseConnector().setNewUser(user: user)
-                        }
-                    }
-                }, label: {
-                    Text("Sign up")
-                })
+//                Button(action: {
+//                    var user = User(id: "testUser2Id", nickname: "testUser2Nickname")
+//                    let image = UIImage(named: "Sample_Profile2")
+//                    if let image = image {
+//                        FirebaseConnector().uploadProfileImage(userId: user.id, image: image) { url in
+//                            user.profileImageUrl = url
+//                            FirebaseConnector().setNewUser(user: user)
+//                        }
+//                    }
+//                }, label: {
+//                    Text("Sign up")
+//                })
                 
                 // 프로필 정보 수정
                 Button(action: {
                     let user = User(id: "testUser1Id", nickname: "testUser1NicknameEdited", profileImageUrl: "https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80")
-                    FirebaseConnector().updateUser(user: user)
+//                    FirebaseConnector().updateUser(user: user)
                 }, label: {
                     Text("Edit User")
                 })

--- a/IAteIt/IAteIt/Utility/Extension/Image+Extension.swift
+++ b/IAteIt/IAteIt/Utility/Extension/Image+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  Image+Extension.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/05/28.
+//
+
+import SwiftUI
+
+extension Image {
+    func circleImage(imageSize: CGFloat) -> some View {
+        self
+            .resizable()
+            .scaledToFill()
+            .frame(width: imageSize, height: imageSize)
+            .clipShape(Circle())
+   }
+}

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -77,7 +77,10 @@ struct FeedView: View {
                                 FeedTitleView()
             .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
         )
-        .navigationBarItems(trailing: NavigationLink(destination: MyProfileView()) {
+        .navigationBarItems(trailing: NavigationLink(destination:
+            MyProfileView()
+            .environmentObject(loginState)
+        ) {
             ProfilePhotoButtonView(loginState: loginState)
         })
         .navigationTitle("")

--- a/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
+++ b/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MyProfileView: View {
+    @EnvironmentObject var loginState: LoginStateModel
 
     var body: some View {
         GeometryReader { g in
@@ -23,6 +24,7 @@ struct MyProfileView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                    NavigationLink(destination: {
                        SettingView()
+                           .environmentObject(loginState)
                    }, label: {
                        Image(systemName: "gearshape")
                    })

--- a/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
@@ -102,6 +102,16 @@ struct EditProfileView: View {
                     Rectangle()
                         .frame(height: 0.75)
                         .foregroundColor(Color(UIColor.systemGray3))
+                    if !isUnique {
+                        HStack {
+                            Spacer()
+                            Text("This username is already taken.")
+                                .font(.caption2)
+                                .foregroundColor(Color(UIColor.systemRed))
+                                .padding(.top, 1)
+                                .padding(.trailing, .paddingHorizontal)
+                        }
+                    }
                 }
                 .padding(.top, 64)
                 .padding(.horizontal, .paddingHorizontal)

--- a/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct EditProfileView: View {
+    @EnvironmentObject var loginState: LoginStateModel
     @State private var imagePickerPresented = false
     @State private var selectedImage: UIImage?
     @State private var profileImage: Image?
@@ -25,25 +26,37 @@ struct EditProfileView: View {
                 Button(action: {
                     imagePickerPresented.toggle()
                 }, label: {
-                    if let image = profileImage {
-                        image
+                    if let newImage = profileImage {
+                        newImage
                             .resizable()
                             .scaledToFill()
                             .frame(width: imgSize, height: imgSize)
                             .clipShape(Circle())
                     } else {
-                        ZStack {
-                            Rectangle()
-                                .foregroundColor(.white)
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: imgSize, height: imgSize)
-                            Image(systemName: "person.crop.circle")
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: imgSize, height: imgSize)
-                                .foregroundColor(Color(UIColor.systemGray2))
+                        if let oldImageUrl = loginState.user?.profileImageUrl {
+                            AsyncImage(url: URL(string: oldImageUrl)) { oldImage in
+                                oldImage
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: imgSize, height: imgSize)
+                                    .clipShape(Circle())
+                            } placeholder: {
+                                Color(UIColor.systemGray5)
+                            }
+                        } else {
+                            ZStack {
+                                Rectangle()
+                                    .foregroundColor(.white)
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: imgSize, height: imgSize)
+                                Image(systemName: "person.crop.circle")
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: imgSize, height: imgSize)
+                                    .foregroundColor(Color(UIColor.systemGray2))
+                            }
+                            .clipShape(Circle())
                         }
-                        .clipShape(Circle())
                     }
                 })
                 .sheet(isPresented: $imagePickerPresented,
@@ -60,7 +73,7 @@ struct EditProfileView: View {
                             Spacer()
                         }
                         .frame(width: 112)
-                        // TODO: textField에 본인 username 넣어두기
+                        
                         TextField("username", text: $username)
                             .limitTextLength($username, to: 16)
                             .textCase(.lowercase)
@@ -70,6 +83,8 @@ struct EditProfileView: View {
                             .focused($isFocused)
                             .onAppear {
                                 UITextField.appearance().clearButtonMode = .whileEditing
+                                guard let oldUsername = loginState.user?.nickname else { return }
+                                username = oldUsername
                             }
                             .onChange(of: username) { _ in
                                 username = username.replacingOccurrences(of: " ", with: "")

--- a/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
@@ -30,25 +30,16 @@ struct EditProfileView: View {
                 }, label: {
                     if let newImage = profileImage {
                         newImage
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: imgSize, height: imgSize)
-                            .clipShape(Circle())
+                            .circleImage(imageSize: imgSize)
                     } else {
                         if let oldImageUrl = loginState.user?.profileImageUrl {
                             AsyncImage(url: URL(string: oldImageUrl)) { oldImage in
                                 oldImage
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width: imgSize, height: imgSize)
-                                    .clipShape(Circle())
+                                    .circleImage(imageSize: imgSize)
                             } placeholder: {
                                 Image(systemName: "person.crop.circle")
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width: imgSize, height: imgSize)
+                                    .circleImage(imageSize: imgSize)
                                     .foregroundColor(Color(UIColor.systemGray2))
-                                    .clipShape(Circle())
                             }
                         } else {
                             ZStack {

--- a/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct EditProfileView: View {
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var loginState: LoginStateModel
+    @State private var isShowingSaveAlert = false
     @State private var imagePickerPresented = false
     @State private var selectedImage: UIImage?
     @State private var profileImage: Image?
@@ -117,7 +118,7 @@ struct EditProfileView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
                     saveProfile()
-                    self.presentationMode.wrappedValue.dismiss()
+                    isShowingSaveAlert = true
                 }, label: {
                    Text("Save")
                        .font(.headline)
@@ -127,6 +128,13 @@ struct EditProfileView: View {
                 )
             }
         }
+        .alert("Changes Saved", isPresented: $isShowingSaveAlert, actions: {
+            Button("OK", role: .cancel, action: {
+                self.presentationMode.wrappedValue.dismiss()
+            })
+        }, message: {
+            Text("Your changed have been saved successfully.")
+        })
     }
 }
 

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 struct SettingView: View {
+    @EnvironmentObject var loginState: LoginStateModel
     
     var body: some View {
         List {
             Section {
                 NavigationLink(destination: {
                     EditProfileView()
+                        .environmentObject(loginState)
                 }, label: {
                     SettingListTitleView(text: "Edit Profile", symbol: "person", color: .black)
                 })

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -14,8 +14,6 @@ struct SignUpSecondView: View {
     @State private var profileImage: Image?
     @State private var isLaterTextPresented = true
     
-//    var user: User?
-    
     let imgSize: CGFloat = 148
     
     var body: some View {
@@ -61,15 +59,7 @@ struct SignUpSecondView: View {
                     .padding(.bottom, 20)
             }
             Button(action: {
-                if let image = selectedImage {
-                    FirebaseConnector.shared.uploadProfileImage(userId: loginState.appleUid, image: image) { url in
-                        let user = User(id: loginState.appleUid, nickname: loginState.username, profileImageUrl: url)
-                        FirebaseConnector.shared.setNewUser(user: user)
-                    }
-                } else {
-                    let user = User(id: loginState.appleUid, nickname: loginState.username)
-                    FirebaseConnector.shared.setNewUser(user: user)
-                }
+                saveAndCompleteSignUp()
                 loginState.isSignUpViewPresent = false
             }, label: {
                 BottomButtonView(label: "Done")
@@ -84,6 +74,19 @@ extension SignUpSecondView {
         guard let selectedImage = selectedImage else { return }
         profileImage = Image(uiImage: selectedImage)
         isLaterTextPresented = false
+    }
+    func saveAndCompleteSignUp() {
+        var user = User(id: loginState.appleUid, nickname: loginState.username)
+        Task {
+            if let image = selectedImage {
+                let imageUrl = try await FirebaseConnector.shared.uploadProfileImage(userId: loginState.appleUid, image: image)
+                user.profileImageUrl = imageUrl
+            }
+            DispatchQueue.main.async {
+                loginState.user = user
+            }
+            FirebaseConnector.shared.setNewUser(user: user)
+        }
     }
 }
 

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -26,10 +26,7 @@ struct SignUpSecondView: View {
             }, label: {
                 if let image = profileImage {
                     image
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: imgSize, height: imgSize)
-                        .clipShape(Circle())
+                        .circleImage(imageSize: imgSize)
                 } else {
                     ZStack {
                         Rectangle()


### PR DESCRIPTION
## 관련 이슈들
- #64 

## 작업 내용
- 프로필 정보(username, 프로필 사진)을 수정하고 저장할 수 있도록 했습니다.

## 리뷰 노트
- user 관련 firebase 함수들이 기존에 만들어둔 것들이어서 async로 수정하면서 SignUpView 쪽도 코드가 조금 수정되었습니다.
- username 중복 체크는 회원가입뷰에서와 동일하게 구현했습니다.
- imagePicker에서 선택한 이미지가 있으면 이미지를 함께 저장하고, 없으면 username만 저장합니다.

## 스크린샷(UX의 경우 gif)
<img src="https://github.com/Bnomad-space/IAteIt/assets/103012157/5e987f57-add3-4544-b06c-89fab0f4bfa0" width="300">

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
