### PR TITLE
[Feat] #65 Delete Account 기능

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		630BA6C029AF57BE00019F2E /* Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6BF29AF57BE00019F2E /* Camera.swift */; };
 		630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630BA6C129AF57F700019F2E /* CameraViewModel.swift */; };
 		6366BA1E29B613C1004374BE /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366BA1D29B613C1004374BE /* CameraPreviewView.swift */; };
+		7E047E4E2A233C4800B29760 /* EnvironmentValues+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E047E4D2A233C4800B29760 /* EnvironmentValues+Extension.swift */; };
 		7E1F719229A8FD9C005A7B56 /* AddCommentBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */; };
 		7E1F719429A90449005A7B56 /* TempPlate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1F719329A90449005A7B56 /* TempPlate.swift */; };
 		7E2B2DAD29DE9304009EC0ED /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B2DAC29DE9304009EC0ED /* Constants.swift */; };
@@ -82,6 +83,7 @@
 		630BA6BF29AF57BE00019F2E /* Camera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Camera.swift; sourceTree = "<group>"; };
 		630BA6C129AF57F700019F2E /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
 		6366BA1D29B613C1004374BE /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
+		7E047E4D2A233C4800B29760 /* EnvironmentValues+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+Extension.swift"; sourceTree = "<group>"; };
 		7E1F719129A8FD9C005A7B56 /* AddCommentBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentBarView.swift; sourceTree = "<group>"; };
 		7E1F719329A90449005A7B56 /* TempPlate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempPlate.swift; sourceTree = "<group>"; };
 		7E2B2DAC29DE9304009EC0ED /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				8C73F00429BDDAE6007D1A1E /* DateFormatter.swift */,
 				7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */,
 				7EDF91AA29E989BD00FB23A8 /* View+Extension.swift */,
+				7E047E4D2A233C4800B29760 /* EnvironmentValues+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -531,6 +534,7 @@
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				7EFFE28829A5228D0021B9FE /* IAteItApp.swift in Sources */,
 				048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */,
+				7E047E4E2A233C4800B29760 /* EnvironmentValues+Extension.swift in Sources */,
 				7E9198A329CF56B400044815 /* LoginView.swift in Sources */,
 				DF2213A229BB2ADC000134FC /* AppDelegate.swift in Sources */,
 				7E48DC1E29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift in Sources */,

--- a/IAteIt/IAteIt/Application/IAteItApp.swift
+++ b/IAteIt/IAteIt/Application/IAteItApp.swift
@@ -14,15 +14,18 @@ struct IAteItApp: App {
     
     @StateObject var loginState: LoginStateModel = LoginStateModel()
     @StateObject var feedMeals: FeedMealModel = FeedMealModel()
+    @State private var isActive: Bool = false
     
     var body: some Scene {
         WindowGroup {
             NavigationView {
-                FeedView()
+                FeedView(isActive: $isActive)
                     .environmentObject(loginState)
                     .environmentObject(feedMeals)
             }
             .accentColor(.black)
+            .navigationViewStyle(StackNavigationViewStyle())
+            .environment(\.rootPresentationMode, self.$isActive)
         }
     }
 }

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForComments.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForComments.swift
@@ -55,4 +55,13 @@ extension FirebaseConnector {
             try await FirebaseConnector.comments.document(commentId).delete()
         }
     }
+    
+    // 특정 user의 모든 comment 삭제
+    func deleteCommentsByUser(userId: String) async throws {
+        let snapshots = try await FirebaseConnector.comments.whereField("userId", isEqualTo: userId).getDocuments()
+        
+        for document in snapshots.documents {
+            try await FirebaseConnector.comments.document(document.documentID).delete()
+        }
+    }
 }

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -131,4 +131,18 @@ extension FirebaseConnector {
             "plates": FieldValue.arrayRemove([plate.firebaseData])
         ])
     }
+    
+    // 특정 user의 모든 meal 삭제(회원탈퇴)
+    func deleteMealsByUser(userId: String) async throws {
+        let snapshots = try await FirebaseConnector.meals.whereField("userId", isEqualTo: userId).getDocuments()
+        
+        for document in snapshots.documents {
+            let meal = try document.data(as: Meal.self)
+            
+            for plate in meal.plates {
+                try await deletePlateImage(plateId: plate.id)
+            }
+            try await FirebaseConnector.meals.document(document.documentID).delete()
+        }
+    }
 }

--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -6,6 +6,7 @@
 //
 
 import Firebase
+import FirebaseAuth
 import FirebaseFirestore
 import FirebaseStorage
 import SwiftUI
@@ -140,5 +141,20 @@ final class FirebaseConnector {
                 completion(imageUrl.absoluteString)
             }
         }
+    }
+    
+    // user profile 이미지 storage에서 삭제
+    func deleteProfileImage(userId: String) async throws {
+        let storageRef = Storage.storage().reference()
+        let imageRef = storageRef.child("profileImage/\(userId)")
+        try await imageRef.delete()
+    }
+    
+    // user 계정 삭제
+    func deleteUserAccount(userId: String) async throws {
+        let user = Auth.auth().currentUser
+        
+        try await FirebaseConnector.users.document(userId).delete()
+        try await user?.delete()
     }
 }

--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -151,10 +151,14 @@ final class FirebaseConnector {
     }
     
     // user 계정 삭제
-    func deleteUserAccount(userId: String) async throws {
-        let user = Auth.auth().currentUser
-        
+    func deleteUser(userId: String) async throws {
         try await FirebaseConnector.users.document(userId).delete()
-        try await user?.delete()
+    }
+    
+    func deleteUserFromAuth() async throws {
+        guard let user = Auth.auth().currentUser else {
+            throw URLError(.badURL)
+        }
+        try await user.delete()
     }
 }

--- a/IAteIt/IAteIt/Utility/Extension/EnvironmentValues+Extension.swift
+++ b/IAteIt/IAteIt/Utility/Extension/EnvironmentValues+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  EnvironmentValues+Extension.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/05/28.
+//
+
+import SwiftUI
+
+struct RootPresentationModeKey: EnvironmentKey {
+    static let defaultValue: Binding<RootPresentationMode> = .constant(RootPresentationMode())
+}
+
+extension EnvironmentValues {
+    var rootPresentationMode: Binding<RootPresentationMode> {
+        get { return self[RootPresentationModeKey.self] }
+        set { self[RootPresentationModeKey.self] = newValue }
+    }
+}
+
+typealias RootPresentationMode = Bool
+
+extension RootPresentationMode {
+    public mutating func dismiss() {
+        self.toggle()
+    }
+}

--- a/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
+++ b/IAteIt/IAteIt/View/Feed/Component/FeedHeaderView.swift
@@ -63,6 +63,6 @@ struct FeedHeaderView: View {
 
 struct FeedHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(cameraViewModel: CameraViewModel())
+        FeedView(cameraViewModel: CameraViewModel(), isActive: .constant(false))
     }
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -78,7 +78,10 @@ struct FeedView: View {
                                 FeedTitleView()
             .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
         )
-        .navigationBarItems(trailing: NavigationLink(destination: MyProfileView()) {
+        .navigationBarItems(trailing: NavigationLink(destination:
+            MyProfileView()
+            .environmentObject(loginState)
+        ) {
             ProfilePhotoButtonView(loginState: loginState)
         })
         .navigationTitle("")

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -14,6 +14,7 @@ struct FeedView: View {
     @EnvironmentObject var loginState: LoginStateModel
     @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isCameraViewPresented = false
+    @Binding var isActive: Bool
     
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -78,12 +79,16 @@ struct FeedView: View {
                                 FeedTitleView()
             .padding([.leading], UIScreen.main.bounds.size.width/2-50) //TODO: 정렬다시
         )
-        .navigationBarItems(trailing: NavigationLink(destination:
-            MyProfileView()
-            .environmentObject(loginState)
-        ) {
-            ProfilePhotoButtonView(loginState: loginState)
-        })
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                NavigationLink(
+                    destination: MyProfileView().environmentObject(loginState),
+                    isActive: $isActive,
+                    label: { ProfilePhotoButtonView(loginState: loginState) }
+                )
+                .isDetailLink(false)
+            }
+        }
         .navigationTitle("")
         .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired, content: {
             LoginView(loginState: loginState)
@@ -96,6 +101,6 @@ struct FeedView: View {
 
 struct FeedView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedView(cameraViewModel: CameraViewModel())
+        FeedView(cameraViewModel: CameraViewModel(), isActive: .constant(false))
     }
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -93,9 +93,6 @@ struct FeedView: View {
         .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired, content: {
             LoginView(loginState: loginState)
         })
-        .fullScreenCover(isPresented: self.$loginState.isSignUpViewPresent, content: {
-            SignUpView(loginState: loginState)
-        })
     }
 }
 

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -87,7 +87,10 @@ struct FeedView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 NavigationLink(
-                    destination: MyProfileView().environmentObject(loginState),
+                    destination:
+                        MyProfileView()
+                            .environmentObject(loginState)
+                            .environmentObject(feedMeals),
                     isActive: $isActive,
                     label: { ProfilePhotoButtonView(loginState: loginState) }
                 )
@@ -96,7 +99,7 @@ struct FeedView: View {
         }
         .navigationTitle("")
         .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired, content: {
-            LoginView(loginState: loginState)
+            LoginView(loginState: loginState, feedMeals: feedMeals)
         })
     }
 }

--- a/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
+++ b/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MyProfileView: View {
+    @EnvironmentObject var loginState: LoginStateModel
 
     var body: some View {
         GeometryReader { g in
@@ -23,6 +24,7 @@ struct MyProfileView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                    NavigationLink(destination: {
                        SettingView()
+                           .environmentObject(loginState)
                    }, label: {
                        Image(systemName: "gearshape")
                    })

--- a/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
+++ b/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MyProfileView: View {
     @EnvironmentObject var loginState: LoginStateModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isActive: Bool = false
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
@@ -26,7 +27,10 @@ struct MyProfileView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink(
-                        destination: SettingView().environmentObject(loginState),
+                        destination:
+                            SettingView()
+                                .environmentObject(loginState)
+                                .environmentObject(feedMeals),
                         isActive: self.$isActive,
                         label: { Image(systemName: "gearshape") }
                     )

--- a/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
+++ b/IAteIt/IAteIt/View/MyProfile/MyProfileView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct MyProfileView: View {
     @EnvironmentObject var loginState: LoginStateModel
+    @State private var isActive: Bool = false
+    @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+    @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
 
     var body: some View {
         GeometryReader { g in
@@ -22,12 +25,12 @@ struct MyProfileView: View {
             .navigationTitle("Profile")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                   NavigationLink(destination: {
-                       SettingView()
-                           .environmentObject(loginState)
-                   }, label: {
-                       Image(systemName: "gearshape")
-                   })
+                    NavigationLink(
+                        destination: SettingView().environmentObject(loginState),
+                        isActive: self.$isActive,
+                        label: { Image(systemName: "gearshape") }
+                    )
+                    .isDetailLink(false)
                }
             }
         }

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -33,7 +33,10 @@ struct SettingView: View {
         }
         .listStyle(.plain)
         .navigationTitle("Settings")
-        .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired, content: {
+        .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired,
+            onDismiss: {
+                loginState.isShowingDeleteAccountCompleteAlert = loginState.isDeleteAccountCompleteAlertRequired
+            }, content: {
             LoginView(loginState: loginState)
         })
         .alert("Delete Account", isPresented: $isShowingDeleteAccountAlert, actions: {

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingView: View {
     @EnvironmentObject var loginState: LoginStateModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isShowingDeleteAccountAlert = false
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
@@ -37,7 +38,7 @@ struct SettingView: View {
             onDismiss: {
                 loginState.isShowingDeleteAccountCompleteAlert = loginState.isDeleteAccountCompleteAlertRequired
             }, content: {
-            LoginView(loginState: loginState)
+                LoginView(loginState: loginState)
         })
         .alert("Delete Account", isPresented: $isShowingDeleteAccountAlert, actions: {
             Button("Delete", role: .destructive, action: {

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct SettingView: View {
     @EnvironmentObject var loginState: LoginStateModel
     @State private var isShowingDeleteAccountAlert = false
+    @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+    @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
     
     var body: some View {
         List {
@@ -30,17 +32,21 @@ struct SettingView: View {
         }
         .listStyle(.plain)
         .navigationTitle("Settings")
+        .fullScreenCover(isPresented: self.$loginState.isAppleLoginRequired, content: {
+            LoginView(loginState: loginState)
+        })
         .alert("Delete Account", isPresented: $isShowingDeleteAccountAlert, actions: {
             Button("Delete", role: .destructive, action: {
-                loginState.deleteAccount()
+                loginState.type = .deleteAccount
+                loginState.isAppleLoginRequired = true
             })
         }, message: {
             Text("Are you sure you want to permanently delete your account and all your data?\nIf you wish to continue with your account deletion, please click “Delete” below. This action is irreversible.")
         })
         .alert("Account Deletion Completed", isPresented: self.$loginState.isShowingDeleteAccountCompleteAlert, actions: {
             Button("OK", role: .cancel, action: {
-                // TODO: feed로 나가기
                 loginState.checkLoginUser()
+                self.rootPresentationMode.wrappedValue.dismiss()
             })
         }, message: {
             Text("Your account have been deleted successfully.")

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SettingView: View {
+    @EnvironmentObject var loginState: LoginStateModel
+    @State private var isShowingDeleteAccountAlert = false
     
     var body: some View {
         List {
@@ -19,11 +21,30 @@ struct SettingView: View {
                 })
             }
             Section(header: Text("Dangerous Area")) {
-                SettingListTitleView(text: "Delete Account", symbol: "trash", color: .red)
+                Button(action: {
+                    isShowingDeleteAccountAlert = true
+                }, label: {
+                    SettingListTitleView(text: "Delete Account", symbol: "trash", color: .red)
+                })
             }
         }
         .listStyle(.plain)
         .navigationTitle("Settings")
+        .alert("Delete Account", isPresented: $isShowingDeleteAccountAlert, actions: {
+            Button("Delete", role: .destructive, action: {
+                loginState.deleteAccount()
+            })
+        }, message: {
+            Text("Are you sure you want to permanently delete your account and all your data?\nIf you wish to continue with your account deletion, please click “Delete” below. This action is irreversible.")
+        })
+        .alert("Account Deletion Completed", isPresented: self.$loginState.isShowingDeleteAccountCompleteAlert, actions: {
+            Button("OK", role: .cancel, action: {
+                // TODO: feed로 나가기
+                loginState.checkLoginUser()
+            })
+        }, message: {
+            Text("Your account have been deleted successfully.")
+        })
     }
 }
 

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -38,7 +38,7 @@ struct SettingView: View {
             onDismiss: {
                 loginState.isShowingDeleteAccountCompleteAlert = loginState.isDeleteAccountCompleteAlertRequired
             }, content: {
-                LoginView(loginState: loginState)
+                LoginView(loginState: loginState, feedMeals: feedMeals)
         })
         .alert("Delete Account", isPresented: $isShowingDeleteAccountAlert, actions: {
             Button("Delete", role: .destructive, action: {

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -16,46 +16,48 @@ struct LoginView: View {
     @State var currentNonce: String?
     
     var body: some View {
-        VStack {
-            Text(loginState.type.setLoginViewTitle())
-                .font(.title)
-                .fontWeight(.bold)
-                .padding([.bottom], 26)
-            Text(loginState.type.setLoginViewContent())
-                .font(.body)
-                .multilineTextAlignment(.center)
-                .padding([.bottom], 44)
-            
-            SignInWithAppleButton(.signIn) { request in
-                let nonce = randomNonceString()
-                currentNonce = nonce
-                request.requestedScopes = [.fullName, .email]
-                request.nonce = sha256(nonce)
-            } onCompletion: { result in
-                loginState.getResultOfAppleLogin(result: result, currentNonce: currentNonce)
-            }
-            .signInWithAppleButtonStyle(.white)
-            .frame(width: 268, height: 50, alignment: .center)
-            .overlay(
+        NavigationView {
+            VStack {
+                Text(loginState.type.setLoginViewTitle())
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .padding([.bottom], 26)
+                Text(loginState.type.setLoginViewContent())
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .padding([.bottom], 44)
+                
+                SignInWithAppleButton(.signIn) { request in
+                    let nonce = randomNonceString()
+                    currentNonce = nonce
+                    request.requestedScopes = [.fullName, .email]
+                    request.nonce = sha256(nonce)
+                } onCompletion: { result in
+                    loginState.getResultOfAppleLogin(result: result, currentNonce: currentNonce)
+                }
+                .signInWithAppleButtonStyle(.white)
+                .frame(width: 268, height: 50, alignment: .center)
+                .overlay(
                     RoundedRectangle(cornerRadius: 25)
                         .stroke(.black, lineWidth: 1)
-            )
-            .padding([.bottom], 32)
-            
-            if loginState.type == .createAccount {
-                Button(action: {
-                    // TODO: 액션 추가
-                }, label: {
-                    Text("I'll sign in next time.")
-                        .font(.body)
-                        .foregroundColor(.gray)
-                        .underline()
-                })
+                )
+                .padding([.bottom], 32)
+                
+                if loginState.type == .createAccount {
+                    Button(action: {
+                        // TODO: 액션 추가
+                    }, label: {
+                        Text("I'll sign in next time.")
+                            .font(.body)
+                            .foregroundColor(.gray)
+                            .underline()
+                    })
+                }
+                NavigationLink(
+                    destination: SignUpView(loginState: loginState),
+                    isActive: self.$loginState.isSignUpRequired
+                ) {}
             }
-        }
-        .onDisappear {
-            loginState.isSignUpViewPresent = loginState.isSignUpRequired
-            loginState.isShowingDeleteAccountCompleteAlert = loginState.isDeleteAccountCompleteAlertRequired
         }
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -11,16 +11,17 @@ import FirebaseAuth
 import SwiftUI
 
 struct LoginView: View {
+    @Environment(\.dismiss) var dismiss
     @ObservedObject var loginState: LoginStateModel
     @State var currentNonce: String?
     
     var body: some View {
         VStack {
-            Text("Sign in required!")
+            Text(loginState.type.setLoginViewTitle())
                 .font(.title)
                 .fontWeight(.bold)
                 .padding([.bottom], 26)
-            Text("Please sign in\nto share what you eat in a day.")
+            Text(loginState.type.setLoginViewContent())
                 .font(.body)
                 .multilineTextAlignment(.center)
                 .padding([.bottom], 44)
@@ -41,17 +42,20 @@ struct LoginView: View {
             )
             .padding([.bottom], 32)
             
-            Button(action: {
-                // TODO: 액션 추가
-            }, label: {
-                Text("I'll sign in next time.")
-                    .font(.body)
-                    .foregroundColor(.gray)
-                    .underline()
-            })
+            if loginState.type == .createAccount {
+                Button(action: {
+                    // TODO: 액션 추가
+                }, label: {
+                    Text("I'll sign in next time.")
+                        .font(.body)
+                        .foregroundColor(.gray)
+                        .underline()
+                })
+            }
         }
         .onDisappear {
             loginState.isSignUpViewPresent = loginState.isSignUpRequired
+            loginState.isShowingDeleteAccountCompleteAlert = loginState.isDeleteAccountCompleteAlertRequired
         }
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct LoginView: View {
     @Environment(\.dismiss) var dismiss
     @ObservedObject var loginState: LoginStateModel
+    @ObservedObject var feedMeals: FeedMealModel
     @State var currentNonce: String?
     
     var body: some View {
@@ -54,7 +55,7 @@ struct LoginView: View {
                     })
                 }
                 NavigationLink(
-                    destination: SignUpView(loginState: loginState),
+                    destination: SignUpView(loginState: loginState, feedMeals: feedMeals),
                     isActive: self.$loginState.isSignUpRequired
                 ) {}
             }
@@ -99,6 +100,6 @@ extension LoginView {
 
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
-        LoginView(loginState: LoginStateModel())
+        LoginView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -152,7 +152,8 @@ class LoginStateModel: ObservableObject {
                     try await FirebaseConnector.shared.deleteProfileImage(userId: userId)
                 }
                 try await FirebaseConnector.shared.deleteUser(userId: userId)
-                // TODO: 유저의 meal history 삭제, storage의 plate 이미지 삭제
+                try await FirebaseConnector.shared.deleteCommentsByUser(userId: userId)
+                // TODO: 유저의 meal history 삭제
                 await MainActor.run {
                     self.user = nil
                     self.isAppleLoginRequired = false

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -153,7 +153,7 @@ class LoginStateModel: ObservableObject {
                 }
                 try await FirebaseConnector.shared.deleteUser(userId: userId)
                 try await FirebaseConnector.shared.deleteCommentsByUser(userId: userId)
-                // TODO: 유저의 meal history 삭제
+                try await FirebaseConnector.shared.deleteMealsByUser(userId: userId)
                 await MainActor.run {
                     self.user = nil
                     self.isAppleLoginRequired = false

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -18,6 +18,7 @@ class LoginStateModel: ObservableObject {
     @Published var isAppleLoginRequired: Bool = false
     @Published var isSignUpViewPresent: Bool = false
     @Published var isSignUpRequired: Bool = false
+    @Published var isShowingDeleteAccountCompleteAlert = false
     
     init() {
         self.checkLoginUser()
@@ -105,6 +106,18 @@ class LoginStateModel: ObservableObject {
                 }
             } catch {
                 print("Error: \(error)")
+            }
+        }
+    }
+    
+    func deleteAccount() {
+        Task {
+            guard let userId = user?.id else { return }
+            try await FirebaseConnector.shared.deleteUserAccount(userId: userId)
+            try await FirebaseConnector.shared.deleteProfileImage(userId: userId)
+            // TODO: 유저의 meal history 삭제, storage의 plate 이미지 삭제
+            DispatchQueue.main.async {
+                self.isShowingDeleteAccountCompleteAlert = true
             }
         }
     }

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SignUpSecondView: View {
     @ObservedObject var loginState: LoginStateModel
-    @EnvironmentObject var feedMeals: FeedMealModel
+    @ObservedObject var feedMeals: FeedMealModel
     @State private var imagePickerPresented = false
     @State private var selectedImage: UIImage?
     @State private var profileImage: Image?
@@ -92,6 +92,6 @@ extension SignUpSecondView {
 
 struct SignUpSecondView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpSecondView(loginState: LoginStateModel())
+        SignUpSecondView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -14,8 +14,6 @@ struct SignUpSecondView: View {
     @State private var profileImage: Image?
     @State private var isLaterTextPresented = true
     
-//    var user: User?
-    
     let imgSize: CGFloat = 148
     
     var body: some View {
@@ -65,10 +63,12 @@ struct SignUpSecondView: View {
                     FirebaseConnector.shared.uploadProfileImage(userId: loginState.appleUid, image: image) { url in
                         let user = User(id: loginState.appleUid, nickname: loginState.username, profileImageUrl: url)
                         FirebaseConnector.shared.setNewUser(user: user)
+                        loginState.user = user
                     }
                 } else {
                     let user = User(id: loginState.appleUid, nickname: loginState.username)
                     FirebaseConnector.shared.setNewUser(user: user)
+                    loginState.user = user
                 }
                 loginState.isSignUpViewPresent = false
             }, label: {

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SignUpSecondView: View {
     @ObservedObject var loginState: LoginStateModel
-    @ObservedObject var feedMeals: FeedMealModel
+    @EnvironmentObject var feedMeals: FeedMealModel
     @State private var imagePickerPresented = false
     @State private var selectedImage: UIImage?
     @State private var profileImage: Image?
@@ -92,6 +92,6 @@ extension SignUpSecondView {
 
 struct SignUpSecondView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpSecondView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        SignUpSecondView(loginState: LoginStateModel())
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -57,7 +57,6 @@ struct SignUpSecondView: View {
             }
             Button(action: {
                 saveAndCompleteSignUp()
-                loginState.isSignUpViewPresent = false
             }, label: {
                 BottomButtonView(label: "Done")
             })
@@ -79,10 +78,12 @@ extension SignUpSecondView {
                 let imageUrl = try await FirebaseConnector.shared.uploadProfileImage(userId: loginState.appleUid, image: image)
                 user.profileImageUrl = imageUrl
             }
+            FirebaseConnector.shared.setNewUser(user: user)
             DispatchQueue.main.async {
                 loginState.user = user
+                loginState.isSignUpRequired = false
+                loginState.isAppleLoginRequired = false
             }
-            FirebaseConnector.shared.setNewUser(user: user)
         }
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -16,62 +16,61 @@ struct SignUpView: View {
     @State var usernameList: [String] = []
     
     var body: some View {
-        NavigationView {
-            VStack {
-                Text("Please create your username.")
-                    .font(.headline)
-                    .padding(.top, 60)
-                TextField("username", text: $username)
-                    .limitTextLength($username, to: 16)
-                    .textCase(.lowercase)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused($isFocused)
-                    .onAppear() {
-                        isFocused = true
-                    }
-                    .onChange(of: username) { _ in
-                        username = username.replacingOccurrences(of: " ", with: "")
-                        isValidFormat = testValidUsername(testString: username)
-                        isUnique = testUnique(testString: username)
-                    }
-                    .font(Font.title2.weight(.bold))
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 40)
-                Text("\(username.count) / 16")
+        VStack {
+            Text("Please create your username.")
+                .font(.headline)
+                .padding(.top, 60)
+            TextField("username", text: $username)
+                .limitTextLength($username, to: 16)
+                .textCase(.lowercase)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused($isFocused)
+                .onAppear() {
+                    isFocused = true
+                }
+                .onChange(of: username) { _ in
+                    username = username.replacingOccurrences(of: " ", with: "")
+                    isValidFormat = testValidUsername(testString: username)
+                    isUnique = testUnique(testString: username)
+                }
+                .font(Font.title2.weight(.bold))
+                .multilineTextAlignment(.center)
+                .padding(.top, 40)
+            Text("\(username.count) / 16")
+                .font(.caption2)
+                .foregroundColor(.gray)
+            if !isUnique {
+                Text("This username is already taken.")
                     .font(.caption2)
-                    .foregroundColor(.gray)
-                if !isUnique {
-                    Text("This username is already taken.")
-                        .font(.caption2)
-                        .foregroundColor(Color(UIColor.systemRed))
-                        .padding(.top, 1)
-                }
+                    .foregroundColor(Color(UIColor.systemRed))
+                    .padding(.top, 1)
+            }
+            Spacer()
+        }
+        .navigationBarHidden(true)
+        .overlay {
+            VStack {
                 Spacer()
+                Text("Username must be 4 to 16 alphanumeric characters.\nThe first character must be a letter.")
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color(UIColor.systemGray))
+                    .padding(.bottom, 20)
+                NavigationLink(destination: SignUpSecondView(loginState: loginState),
+                    label: {
+                    BottomButtonView(label: "Next")
+                })
+                .disabled(
+                    !isValidFormat || !isUnique
+                )
+                .simultaneousGesture(TapGesture().onEnded {
+                    loginState.username = username
+                })
             }
-            .overlay {
-                VStack {
-                    Spacer()
-                    Text("Username must be 4 to 16 alphanumeric characters.\nThe first character must be a letter.")
-                        .font(.subheadline)
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(Color(UIColor.systemGray))
-                        .padding(.bottom, 20)
-                    NavigationLink(destination: SignUpSecondView(loginState: loginState),
-                        label: {
-                        BottomButtonView(label: "Next")
-                    })
-                    .disabled(
-                        !isValidFormat || !isUnique
-                    )
-                    .simultaneousGesture(TapGesture().onEnded {
-                        loginState.username = username
-                    })
-                }
-            }
-            .onAppear {
-                getAllUsernames()
-            }
+        }
+        .onAppear {
+            getAllUsernames()
         }
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SignUpView: View {
     @ObservedObject var loginState: LoginStateModel
+    @ObservedObject var feedMeals: FeedMealModel
     @FocusState private var isFocused: Bool
     @State var username = ""
     @State var isValidFormat: Bool = false
@@ -57,7 +58,7 @@ struct SignUpView: View {
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color(UIColor.systemGray))
                     .padding(.bottom, 20)
-                NavigationLink(destination: SignUpSecondView(loginState: loginState),
+                NavigationLink(destination: SignUpSecondView(loginState: loginState, feedMeals: feedMeals),
                     label: {
                     BottomButtonView(label: "Next")
                 })
@@ -97,6 +98,6 @@ extension SignUpView {
 
 struct SignUpView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpView(loginState: LoginStateModel())
+        SignUpView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SignUpView: View {
     @ObservedObject var loginState: LoginStateModel
-    @ObservedObject var feedMeals: FeedMealModel
     @FocusState private var isFocused: Bool
     @State var username = ""
     @State var isValidFormat: Bool = false
@@ -98,6 +97,6 @@ extension SignUpView {
 
 struct SignUpView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
+        SignUpView(loginState: LoginStateModel())
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #66 

## 작업 내용
- SettingView에 로그인한 유저 계정 삭제 기능을 추가했습니다.
- 계정 삭제 UX는 다음과 같습니다.
    - Delete Account 누르기
    - 계정 삭제 확인 alert에서 Delete 누르기
    - LoginView에서 한번 더 Sign in with Apple
    - 계정 삭제 완료 alert에서 OK 누르기
    - FeedView로 나가지고 LoginView(+회원가입) 뜸

## 리뷰 노트
- 계정 삭제 flow에 대해서는 논의된 바 없어 일단 유저의 조작에 따라 아래 항목이 삭제되도록 작업했습니다. 추후 삭제 시기와 범위에 대해 고민 후 수정 필요합니다..
    - firebase 데이터베이스 users 콜렉션에서 해당 유저 document 삭제
    - firebase Authentication에서 해당 유저 계정 삭제
    - firebase storage에서 해당 유저 프로필이미지 삭제
- 계정 삭제 확인할 때 뜨는 LoginView는 .createAccount/.deleteAccount의 두 가지 type을 만들어서 표시되는 텍스트만 다르게 재활용했습니다.
- 계정 삭제 확인용으로 Sign in with Apple을 한번 더 하지 않고 바로 user.delete()를 시도하면 아래와 같은 에러가 나서 추가했습니다..

> Error Domain=FIRAuthErrorDomain Code=17014 "This operation is sensitive and requires recent authentication. Log in again before retrying this request." UserInfo={NSLocalizedDescription=This operation is sensitive and requires recent authentication. Log in again before retrying this request., FIRAuthErrorUserInfoNameKey=ERROR_REQUIRES_RECENT_LOGIN}

- 처음 앱 설치 후 계정 만들 때도 마찬가지였듯이 일단 앱을 애플로그인/회원가입 완료한 사용자만 사용할 수 있는 것으로 생각했습니다. 그래서 계정 삭제 완료 후 Feed로 나가지만 회원가입 화면이 바로 뜨도록 했습니다.

(추가)
- 유저가 올린 meal과 plate 사진들 삭제하는 기능 일단 제외했습니다.(그에따라 삭제된 유저가 올린 meal, comment 표시 시 에러 발생가능..)

## 스크린샷(UX의 경우 gif)
<img src="https://github.com/Bnomad-space/IAteIt/assets/103012157/30adf359-2872-47ac-bb24-bcda4ac29171" width="300">

## Reference
- [Pop to the root view using SwiftUI](https://stackoverflow.com/questions/57334455/how-can-i-pop-to-the-root-view-using-swiftui)
- [Firebase에서 사용자 관리하기](https://firebase.google.com/docs/auth/ios/manage-users?hl=ko)
- [Firebase Apple 플랫폼 인증 오류 처리](https://firebase.google.com/docs/auth/ios/errors?hl=ko)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
