### PR TITLE
[Feat] DetailView comment 바운딩박스, 흰배경 추가

### DIFF
--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -81,10 +81,24 @@ struct MealDetailView: View {
                                 Text("Comment Error")
                             }
                         }
+                        Rectangle()
+                            .fill(Color.white.opacity(0))
+                            .frame(height: 100)
                     }
                     .padding([.top], 24)
                     .padding(.horizontal, .paddingHorizontal)
                 }
+            }
+            VStack {
+                Spacer()
+                Rectangle()
+                    .fill(
+                        LinearGradient(gradient: Gradient(colors: [Color.white, Color.white.opacity(0)]),
+                                       startPoint: UnitPoint(x: 0.5, y: 1-100/200),
+                                       endPoint: .top)
+                    )
+                    .ignoresSafeArea()
+                    .frame(height: 150)
             }
             AddCommentBarView(feedMeals: feedMeals, commentBar: commentBar, meal: meal)
                 .padding([.bottom], 10)


### PR DESCRIPTION
## 관련 이슈들
#69 

## 작업 내용
- 작업한 내용을 풍부한 맥락과 함께 공유해주세요.

## 리뷰 노트
- comment가 많은 경우에 comment 입력창에 의해 가려지지 않도록 맨 아래에 투명한 박스를 Vstack으로 추가했습니다.
- foreach(commentView)와 addCommentBarView 사이에 Zstack으로 흰색 박스를 추가했습니다.
## 스크린샷(UX의 경우 gif)
<img width="300" alt="스크린샷 2023-06-03 15 05 54" src="https://github.com/Bnomad-space/IAteIt/assets/70618615/b231272d-0460-4b58-b397-3a45c4cb54fa">     <img width="300" alt="스크린샷 2023-06-03 15 06 08" src="https://github.com/Bnomad-space/IAteIt/assets/70618615/2ab7cefb-566d-441e-8616-181d43d82671">

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
