### PR TITLE
[Bug] #72 가입하고 바로 코멘트 남기면 comment error로 뜨는 문제 수정

### DIFF
--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -24,8 +24,8 @@ final class FirebaseConnector {
     static let users = Firestore.firestore().collection("users")
     
     // 새로운 user 생성(회원가입)
-    func setNewUser(user: User) {
-        FirebaseConnector.users.document(user.id).setData([
+    func setNewUser(user: User) async throws {
+        try await FirebaseConnector.users.document(user.id).setData([
             "id": user.id,
             "nickname": user.nickname,
             "profileImageUrl": user.profileImageUrl as Any

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -76,7 +76,7 @@ struct FeedView: View {
         .refreshable {
           do {
             try await Task.sleep(nanoseconds: 1_000_000_000)
-            feedMeals.getMealListIn24Hours()
+              feedMeals.refreshMealsAndUsers()
           } catch {print("Error refreshing data: \(error)")}
         }
         .navigationBarItems(leading:
@@ -94,7 +94,7 @@ struct FeedView: View {
             LoginView(loginState: loginState)
         })
         .fullScreenCover(isPresented: self.$loginState.isSignUpViewPresent, content: {
-            SignUpView(loginState: loginState)
+            SignUpView(loginState: loginState, feedMeals: feedMeals)
         })
     }
 }

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -18,13 +18,7 @@ final class FeedMealModel: ObservableObject {
     @Published var commentList: [String: [Comment]] = [:]
     
     init() {
-        Task {
-            let fetchAllUser = try await FirebaseConnector.shared.fetchAllUsers()
-            await MainActor.run {
-                self.allUsers = fetchAllUser
-                self.getMealListIn24Hours()
-            }
-        }
+        self.refreshMealsAndUsers()
     }
     
     @MainActor
@@ -101,6 +95,16 @@ final class FeedMealModel: ObservableObject {
             }
             DispatchQueue.main.async {
                 self.mealList.removeAll(where: { $0.id == mealId })
+            }
+        }
+    }
+    
+    func refreshMealsAndUsers() {
+        Task {
+            let fetchAllUser = try await FirebaseConnector.shared.fetchAllUsers()
+            await MainActor.run {
+                self.allUsers = fetchAllUser
+                self.getMealListIn24Hours()
             }
         }
     }

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SignUpSecondView: View {
     @ObservedObject var loginState: LoginStateModel
+    @ObservedObject var feedMeals: FeedMealModel
     @State private var imagePickerPresented = false
     @State private var selectedImage: UIImage?
     @State private var profileImage: Image?
@@ -79,16 +80,17 @@ extension SignUpSecondView {
                 let imageUrl = try await FirebaseConnector.shared.uploadProfileImage(userId: loginState.appleUid, image: image)
                 user.profileImageUrl = imageUrl
             }
-            DispatchQueue.main.async {
+            try await FirebaseConnector.shared.setNewUser(user: user)
+            await MainActor.run {
                 loginState.user = user
+                feedMeals.refreshMealsAndUsers()
             }
-            FirebaseConnector.shared.setNewUser(user: user)
         }
     }
 }
 
 struct SignUpSecondView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpSecondView(loginState: LoginStateModel())
+        SignUpSecondView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SignUpView: View {
     @ObservedObject var loginState: LoginStateModel
+    @ObservedObject var feedMeals: FeedMealModel
     @FocusState private var isFocused: Bool
     @State var username = ""
     @State var isValidFormat: Bool = false
@@ -57,7 +58,7 @@ struct SignUpView: View {
                         .multilineTextAlignment(.center)
                         .foregroundColor(Color(UIColor.systemGray))
                         .padding(.bottom, 20)
-                    NavigationLink(destination: SignUpSecondView(loginState: loginState),
+                    NavigationLink(destination: SignUpSecondView(loginState: loginState, feedMeals: feedMeals),
                         label: {
                         BottomButtonView(label: "Next")
                     })
@@ -98,6 +99,6 @@ extension SignUpView {
 
 struct SignUpView_Previews: PreviewProvider {
     static var previews: some View {
-        SignUpView(loginState: LoginStateModel())
+        SignUpView(loginState: LoginStateModel(), feedMeals: FeedMealModel())
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #72 

## 작업 내용
- 가입완료 시 feedMeals의 allUsers와 mealList가 리프레시되도록 했습니다.
    - refresh하는 함수를 만들어서 FeedView의 당겨서 리프레시하는 부분에도 적용했습니다.

## 리뷰 노트
- 탈퇴한 유저(서버 users에 없는 유저)의 코멘트는 아직 comment error로 보이는데, 탈퇴 시 유저 meal, plates, comments 삭제하는 것 추가 작업 필요합니다.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
