### PR TITLE
[Bug] Unexpected NavigationPop by ForEach()

### DIFF
--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -34,7 +34,7 @@ struct FeedView: View {
                 })
                 switch feedMeals.mealList.count != 0 {
                 case true:
-                    ForEach(feedMeals.mealList, id: \.self) { eachMeal in
+                    ForEach(feedMeals.mealList, id: \.id) { eachMeal in
                         if let user = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
                             VStack(spacing: 8) {
                                 FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: user)

--- a/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/AddCommentBarView.swift
@@ -12,7 +12,7 @@ struct AddCommentBarView: View {
     @ObservedObject var commentBar: CommentBar
     @FocusState var isFocused: Bool
     
-    var meal: Meal
+    @State var meal: Meal
     
     var body: some View {
         VStack {
@@ -42,8 +42,10 @@ struct AddCommentBarView: View {
                         if commentBar.type == .comment {
                             feedMeals.commentUpload(meal: meal, comment: commentBar.input)
                         } else if commentBar.type == .caption {
+                            meal.caption = commentBar.input
                             feedMeals.saveCaption(meal: meal, content: commentBar.input)
                         } else if commentBar.type == .location {
+                            meal.location = commentBar.input
                             feedMeals.saveLocation(meal: meal, content: commentBar.input)
                         }
                         isFocused = false

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -34,7 +34,7 @@ struct MealDetailView: View {
                         .padding(.horizontal, .paddingHorizontal)
                     
                     TabView {
-                        ForEach(meal.plates, id: \.self) { plate in
+                        ForEach(meal.plates, id: \.id) { plate in
                             PhotoCardView(plate: plate)
                                 .padding(.horizontal, .paddingHorizontal)
                                 .contextMenu {


### PR DESCRIPTION
## Commit Detail
- ForEach(.. id:\.@@@) 에서 '@' 를 self로 두어 hash값이 변하는 문제

## 문제 상황
- 문제였던 코드 `ForEach(feedMeals.mealList, id: \.id) { eachMeal in ...}`를 예시로 들면, `id: \.self` 부분이 Meal의 모든 프로퍼티(id, userId, caption, location...)를 해시값으로 합쳐서 각 plate를 구분하는데, caption과 같은 값이 변경되게 되면, 결국 해당 Meal의 해시값이 바뀌어 ForEach() 자체가 Refresh되는 현상이었고, 이 ForEach가 chaining되어 `MealDetailView -> FeedView`의 ForEach()에 영향을 주어 처음 화면으로 Pop 되었습니다

## 해결 방법
- ForEach()의 `\.self` 부분을 Meal 혹은 Plate에 유일한 값(id)으로 변경해주어, 'caption, location' 등의 값이 변해도 해시값에 변화가 안생기도록 만들어 주었습니다

## More
- comment의 경우에도 동일한 문제인데, 해결방법을 다르게 한 것 같아, 추후 수정이 필요해 보입니다.
- 고민한거에 비해 적은 코드수정이네요 ㅎ...😂

## 스크린샷(UX의 경우 gif)
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-18 at 00 23 12](https://github.com/Bnomad-space/IAteIt/assets/72736657/382436e9-05e8-4314-81e5-569fd7379799)


## Reference
- [Unexpected NavigationPop](https://velog.io/@looloolalaa/SwiftUI-NavigationLink-pops-back-unexpectedly)
