### PR TITLE
[Enhancement] #84 Firestore database에 meal 저장하는 구조 변경

### DIFF
--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -87,11 +87,21 @@ extension FirebaseConnector {
             .whereField("userId", isEqualTo: userId)
             .order(by: "uploadDate", descending: true)
             .getDocuments()
+        
+        let oldsnapshots = try await FirebaseConnector.meals
+            .whereField("userId", isEqualTo: userId)
+            .getDocuments()
                 
         for document in snapshots.documents {
             let meal = try document.data(as: Meal.self)
             mealHistory.append(meal)
         }
+        
+        for document in oldsnapshots.documents {
+            let meal = try document.data(as: Meal.self)
+            mealHistory.append(meal)
+        }
+        
         return mealHistory
     }
     

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -12,10 +12,13 @@ import SwiftUI
 
 extension FirebaseConnector {
     static let meals = Firestore.firestore().collection("meals")
+    static let meals2 = Firestore.firestore().collection("meals2")
     
     // 새로운 meal 생성 (첫번째 plate 생성 포함, 캡션, 장소 없는 상태)
     func setNewMeal(meal: Meal) async throws -> String {
-        let document = FirebaseConnector.meals.document()
+        let date = Date().toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(date).collection("mealsByDay")
+        let document = mealRef.document()
         let documentId = document.documentID
         var plate = meal.plates[0]
         plate.mealId = documentId
@@ -24,15 +27,19 @@ extension FirebaseConnector {
             "userId": meal.userId,
             "uploadDate": meal.uploadDate
         ])
-        try await FirebaseConnector.meals.document(documentId).updateData([
+        try await document.updateData([
             "plates": FieldValue.arrayUnion([plate.firebaseData])
         ])
         return documentId
     }
     
     // 특정 meal에 새로운 plate 추가
-    func addPlateToMeal(mealId: String, plate: Plate) async throws {
-        try await FirebaseConnector.meals.document(mealId).updateData([
+    func addPlateToMeal(meal: Meal, plate: Plate) async throws {
+        guard let mealId = meal.id else { return }
+        let dateString = meal.uploadDate.toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(dateString).collection("mealsByDay")
+        
+        try await mealRef.document(mealId).updateData([
             "plates": FieldValue.arrayUnion([plate.firebaseData])
         ])
     }
@@ -51,15 +58,23 @@ extension FirebaseConnector {
     }
     
     // 특정 meal에 caption 업데이트
-    func setMealCaption(mealId: String, caption: String) async {
-        try? await FirebaseConnector.meals.document(mealId).updateData([
+    func setMealCaption(meal: Meal, caption: String) async {
+        guard let mealId = meal.id else { return }
+        let date = meal.uploadDate.toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(date).collection("mealsByDay")
+        
+        try? await mealRef.document(mealId).updateData([
             "caption": caption as Any
         ])
     }
     
     // 특정 meal에 location 업데이트
-    func setMealLocation(mealId: String, location: String) async {
-        try? await FirebaseConnector.meals.document(mealId).updateData([
+    func setMealLocation(meal: Meal, location: String) async {
+        guard let mealId = meal.id else { return }
+        let date = meal.uploadDate.toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(date).collection("mealsByDay")
+        
+        try? await mealRef.document(mealId).updateData([
             "location": location as Any
         ])
     }
@@ -68,9 +83,9 @@ extension FirebaseConnector {
     func fetchUserMealHistory(userId: String) async throws -> [Meal] {
         var mealHistory: [Meal] = []
         
-        let snapshots = try await FirebaseConnector.meals
-//            .order(by: "uploadDate", descending: true)
+        let snapshots = try await Firestore.firestore().collectionGroup("mealsByDay")
             .whereField("userId", isEqualTo: userId)
+            .order(by: "uploadDate", descending: true)
             .getDocuments()
                 
         for document in snapshots.documents {
@@ -89,15 +104,26 @@ extension FirebaseConnector {
         let fromTime = date-3600*24
         let fromTimestamp = Timestamp(date: fromTime)
 
-        let snapshots = try await FirebaseConnector.meals.order(by: "uploadDate", descending: true)
+        let snapshotsToday = try await FirebaseConnector.meals2.document(date.toDateString2()).collection("mealsByDay")
+            .order(by: "uploadDate", descending: true)
+            .getDocuments()
+        
+        let snapshotsYesterday = try await FirebaseConnector.meals2.document(fromTime.toDateString2()).collection("mealsByDay")
+            .order(by: "uploadDate", descending: true)
             .whereField("uploadDate", isGreaterThan: fromTimestamp)
             .whereField("uploadDate", isLessThanOrEqualTo: toTimestamp)
             .getDocuments()
         
-        for document in snapshots.documents {
+        for document in snapshotsToday.documents {
             let meal = try document.data(as: Meal.self)
             meals.append(meal)
         }
+        
+        for document in snapshotsYesterday.documents {
+            let meal = try document.data(as: Meal.self)
+            meals.append(meal)
+        }
+        
         return meals
     }
     
@@ -110,13 +136,21 @@ extension FirebaseConnector {
     }
     
     // 특정 meal 삭제
-    func deleteMeal(mealId: String) async throws {
-        try await FirebaseConnector.meals.document(mealId).delete()
+    func deleteMeal(meal: Meal) async throws {
+        guard let mealId = meal.id else { return }
+        let date = meal.uploadDate.toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(date).collection("mealsByDay")
+        
+        try await mealRef.document(mealId).delete()
     }
     
     // 특정 plate 삭제
-    func deletePlate(mealId: String, plate: Plate) async throws {
-        try await FirebaseConnector.meals.document(mealId).updateData([
+    func deletePlate(meal: Meal, plate: Plate) async throws {
+        guard let mealId = meal.id else { return }
+        let date = meal.uploadDate.toDateString2()
+        let mealRef = FirebaseConnector.meals2.document(date).collection("mealsByDay")
+        
+        try await mealRef.document(mealId).updateData([
             "plates": FieldValue.arrayRemove([plate.firebaseData])
         ])
     }

--- a/IAteIt/IAteIt/Utility/Extension/DateFormatter.swift
+++ b/IAteIt/IAteIt/Utility/Extension/DateFormatter.swift
@@ -16,6 +16,14 @@ extension Date {
         let date_string = formatter.string(from: self)
         return date_string
     }
+    
+    func toDateString2() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let date_string = formatter.string(from: self)
+        return date_string
+    }
+    
     /// dateFormat = "yyyy-MM-dd HH:mm:ss" ex) 2021-10-18 12:00:00
     func toDateTimeString() -> String {
         let formatter = DateFormatter()

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -65,7 +65,7 @@ final class FeedMealModel: ObservableObject {
     
     func saveCaption(meal: Meal, content: String) {
         Task {
-            await FirebaseConnector.shared.setMealCaption(mealId: meal.id!, caption: content)
+            await FirebaseConnector.shared.setMealCaption(meal: meal, caption: content)
             mealList.indices.forEach { index in
                 if mealList[index].id == meal.id {
                     DispatchQueue.main.async {
@@ -78,7 +78,7 @@ final class FeedMealModel: ObservableObject {
     
     func saveLocation(meal: Meal, content: String) {
         Task {
-            await FirebaseConnector.shared.setMealLocation(mealId: meal.id!, location: content)
+            await FirebaseConnector.shared.setMealLocation(meal: meal, location: content)
             mealList.indices.forEach { index in
                 if mealList[index].id == meal.id {
                     DispatchQueue.main.async {
@@ -92,7 +92,7 @@ final class FeedMealModel: ObservableObject {
     func deletePlate(meal: Meal, plate: Plate) {
         Task {
             guard let mealId = meal.id else { return }
-            try await FirebaseConnector.shared.deletePlate(mealId: mealId, plate: plate)
+            try await FirebaseConnector.shared.deletePlate(meal: meal, plate: plate)
             try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
             DispatchQueue.main.async {
                 if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
@@ -105,7 +105,7 @@ final class FeedMealModel: ObservableObject {
     func deleteMeal(meal: Meal) {
         Task {
             guard let mealId = meal.id else { return }
-            try await FirebaseConnector.shared.deleteMeal(mealId: mealId)
+            try await FirebaseConnector.shared.deleteMeal(meal: meal)
             if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
                 for plate in self.mealList[index].plates {
                     try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -179,6 +179,7 @@ extension CameraView {
         }
     }
     func saveAddPlate() {
+        guard let meal = mealAddPlateTo else { return }
         guard let mealId = mealAddPlateTo?.id,
               let image = viewModel.imageToBeUploaded
         else { return }
@@ -188,11 +189,11 @@ extension CameraView {
             let plateImageUrl = try await FirebaseConnector.shared.uploadPlateImage(plateId: plate.id, image: image)
             plate.imageUrl = plateImageUrl
             DispatchQueue.main.async {
-                if let index = feedMeals.mealList.firstIndex(where: {$0.id == mealId}) {
+                if let index = feedMeals.mealList.firstIndex(where: {$0.id == meal.id}) {
                     feedMeals.mealList[index].plates.append(plate)
                 }
             }
-            try await FirebaseConnector.shared.addPlateToMeal(mealId: mealId, plate: plate)
+            try await FirebaseConnector.shared.addPlateToMeal(meal: meal, plate: plate)
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #84 

## 작업 내용
파이어베이스 데이터베이스에 meal을 날짜별로 모아서 저장하고, FeedView에 표시할 때는 최근 이틀간의 그룹에서만 24시간 이내 게시물을 검색하여 가져오도록 수정했습니다.

### Before
<img width="528" alt="Screenshot 2023-07-20 at 11 13 13 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/e0d26b9a-a4fb-4cfe-a7bc-00809698a6ba">

### After
<img width="583" alt="Screenshot 2023-07-20 at 11 13 52 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/ff518116-e0e5-4705-a6a6-5e13d22ac82a">

## 리뷰 노트
- 개발 기간 동안 저희가 올린 meal history가 왠지 아까워서 프로필뷰에서 이전 meal들도 보이도록 했습니다..
- 기존 방식은 지난 몇달(?)동안 저희끼리 사용해보면서 어느정도 테스트가 된 것 같은데 새로운 저장 방식은 지속적으로 잘 동작할지 걱정되긴 합니다.. 제가 게시물 몇개는 올리고 삭제하고 해보긴 했는데 출시 전까지 충분한 테스트가 되어야 할 것 같습니다!

## 스크린샷(UX의 경우 gif)
<img width="600" alt="Screenshot 2023-07-20 at 11 11 00 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/5747c878-6c8e-40a8-8fb6-4bac1879084a">

## Reference
- [FireStore 의 Collection Group Query 알아보기](https://joycehong0524.medium.com/firestore-의-collection-group-query-51dcd64a5fd3)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
