### PR TITLE
[fix] #89 알파벳 소문자로 회원가입

### DIFF
--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -64,7 +64,7 @@ final class FirebaseConnector {
                 for document in snapshot!.documents {
                     let dict = document.data()
                     guard let username = dict["nickname"] as? String else { return }
-                    usernameList.append(username)
+                    usernameList.append(username.lowercased())
                 }
                 completion(usernameList)
             }

--- a/IAteIt/IAteIt/View/SignUp/LoginView.swift
+++ b/IAteIt/IAteIt/View/SignUp/LoginView.swift
@@ -44,16 +44,16 @@ struct LoginView: View {
                 )
                 .padding([.bottom], 32)
                 
-                if loginState.type == .createAccount {
-                    Button(action: {
-                        // TODO: 액션 추가
-                    }, label: {
-                        Text("I'll sign in next time.")
-                            .font(.body)
-                            .foregroundColor(.gray)
-                            .underline()
-                    })
-                }
+//                if loginState.type == .createAccount {
+//                    Button(action: {
+//                        // TODO: 액션 추가
+//                    }, label: {
+//                        Text("I'll sign in next time.")
+//                            .font(.body)
+//                            .foregroundColor(.gray)
+//                            .underline()
+//                    })
+//                }
                 NavigationLink(
                     destination: SignUpView(loginState: loginState, feedMeals: feedMeals),
                     isActive: self.$loginState.isSignUpRequired

--- a/IAteIt/IAteIt/View/SignUp/SignUpView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpView.swift
@@ -33,7 +33,7 @@ struct SignUpView: View {
                 .onChange(of: username) { _ in
                     username = username.replacingOccurrences(of: " ", with: "")
                     isValidFormat = testValidUsername(testString: username)
-                    isUnique = testUnique(testString: username)
+                    isUnique = testUnique(testString: username.lowercased())
                 }
                 .font(Font.title2.weight(.bold))
                 .multilineTextAlignment(.center)
@@ -66,7 +66,7 @@ struct SignUpView: View {
                     !isValidFormat || !isUnique
                 )
                 .simultaneousGesture(TapGesture().onEnded {
-                    loginState.username = username
+                    loginState.username = username.lowercased()
                 })
             }
         }


### PR DESCRIPTION
- loginView 다음에 로그인하기 버튼 주석처리

## 관련 이슈들
- #89 

## 작업 내용
- 회원가입 시 유저네임을 소문자로 변환하여 중복체크하고, 소문자로 저장하도록 했습니다.
- 애플로그인뷰에서 다음에 로그인하겠다는 문구의 버튼을 삭제했습니다.

## 리뷰 노트
- 다음에 로그인하기 문구는 피그마에는 그려놓았지만 회원가입/로그인하지 않은 채로 앱을 사용하는 경우는 배제하고 개발했기 때문에 우선 삭제했습니다.

## 스크린샷(UX의 경우 gif)
<p list="left">
<img width="300" alt="Screenshot 2023-07-21 at 6 47 53 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/29e83c86-61ec-4671-850a-33a8440b23bb">
<img width="300" alt="Screenshot 2023-07-21 at 6 47 48 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/26b67020-9f16-43a1-9982-f7e5f2977a6c">
</p>
<p list="left">
<img width="300" alt="Screenshot 2023-07-21 at 6 45 58 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/02e9752d-836d-4f96-a5e2-148c61aa26a7">
<img width="337" alt="Screenshot 2023-07-21 at 6 47 12 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/93bb2b94-0d39-433a-b0f8-004ede689a13">
</p>

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
