### PR TITLE
[Feat] reportView UI 수정

### DIFF
--- a/IAteIt/IAteIt/View/MealDetail/Component/ReportView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/ReportView.swift
@@ -8,36 +8,82 @@
 import SwiftUI
 
 struct ReportView: View {
+    let photoCorner: CGFloat = 20
+    let iconSize: CGFloat = 48
     var meal: Meal
+    var user: User
     var reason = ""
     @EnvironmentObject var loginState: LoginStateModel
     @Binding var isReportPresented: Bool
+    @State private var isAlertPresented: Bool = false
     @State private var text: String = ""
 
     var body: some View {
-        VStack {
-            HStack {
-                Button(action: {
-                    isReportPresented = false
-                }, label: {
-                    Text("취소")
-                        .foregroundColor(.blue)
-                })
-                .padding()
+        NavigationView{
+            VStack {
+                
+                Text("\(user.nickname)'s meal")
+                    .fontWeight(.semibold)
+                    .padding(20)
+                
+                ZStack {
+                    Rectangle()
+                        .aspectRatio(1, contentMode: .fit)
+                        .cornerRadius(photoCorner)
+                        .foregroundColor(.white)
+                    
+                    if let url = URL(string: meal.plates[0].imageUrl) {
+                        CacheAsyncImage(url: url) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .layoutPriority(-1)
+                                    .cornerRadius(photoCorner)
+                            case .failure(_):
+                                PlateImageErrorView(iconSize: iconSize)
+                            case .empty:
+                                Color(UIColor.systemGray6)
+                            @unknown default:
+                                PlateImageErrorView(iconSize: iconSize)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 100)
+                .clipped()
+                .cornerRadius(photoCorner)
+                
+                TextField("Please tell us why you are reporting this meal.", text: $text)
+                    .frame(height: 100)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal)
                 Spacer()
             }
-            Spacer()
-            Text("신고하겠습니다")
-            TextField("Enter text", text: $text)
-                            .frame(height: 100)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-            Button(action: {
-                FirebaseConnector().sendReport(reporterId: loginState.user?.id ?? "", reportedTime: Date(), mealId: meal.id ?? "", reason: text)
-                isReportPresented = false
-            }, label: {
-                Label("신고하기", systemImage: "trash")
+            .navigationBarTitle("Report", displayMode: .inline)
+            .navigationBarItems(leading: Button(action: {
+                                        isReportPresented = false
+                                    }, label: {
+                                        Image(systemName: "xmark")
+                                            .foregroundColor(.black)
+                                    }),
+                                    trailing:
+                                        Button(action: {
+                                            FirebaseConnector().sendReport(reporterId: loginState.user?.id ?? "", reportedTime: Date(), mealId: meal.id ?? "", reason: text)
+                                            isAlertPresented = true
+                                        }, label: {
+                                            Image(systemName: "paperplane.fill")
+                                                .foregroundColor(.black)
+                                        })
+                                )
+            .alert("Report Completed", isPresented: $isAlertPresented, actions: {
+                Button("OK", role: .cancel, action: {
+                    isReportPresented = false
+                })
+            }, message: {
+                Text("Your report has been submitted successfully.")
             })
-            Spacer()
         }
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -21,7 +21,6 @@ struct MealDetailView: View {
     @State private var isShowingPlateDeleteAlert = false
     @State private var isReportPresented = false
     
-    
     var meal: Meal
     var user: User
     var commentList: [String: [Comment]]
@@ -128,29 +127,29 @@ struct MealDetailView: View {
         }, message: {
             Text("This action is irreversible.")
         })
+        .sheet(isPresented: $isReportPresented) {
+            ReportView(meal: meal, user: user, isReportPresented: $isReportPresented)
+                    .environmentObject(loginState)
+                }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                if isMyMeal {
                     Menu(content: {
-                        Button(role: .destructive, action: {
-                            isShowingMealDeleteAlert = true
-                        }, label: {
-                            Label("Delete this meal", systemImage: "trash")
-                        })
+                        if isMyMeal {
+                            Button(role: .destructive, action: {
+                                isShowingMealDeleteAlert = true
+                            }, label: {
+                                Label("Delete this meal", systemImage: "trash")
+                            })
+                        } else {
+                                Button(role: .destructive, action: {
+                                    isReportPresented = true
+                                }, label: {
+                                    Label("Report this meal", systemImage: "exclamationmark.triangle")
+                                })
+                        }
                     }, label: {
                         Image(systemName: "ellipsis")
                     })
-                } else {
-                    Button(action: {
-                        isReportPresented = true
-                    }, label: {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                    })
-                    .sheet(isPresented: $isReportPresented) {
-                        ReportView(meal: meal, isReportPresented: $isReportPresented)
-                            .environmentObject(loginState)
-                            }
-                }
             }
         }
         .onAppear {


### PR DESCRIPTION
## 관련 이슈들
- #91 

## 작업 내용
- Figma에 등록된 reportView UI와 동일하게 어플 UI를 수정했습니다.

## 리뷰 노트
- Alert가 모달이 닫히고 난 후 나오게 하고 싶은데 잘 안되네요 ,, 이유를 모르겠습니다 ㅜㅜ 그래서 지금은 전송 버튼이 Alert를 띄우고, Alert의 OK 버튼이 모달을 닫게 (isModalPresented = false) 되어있습니다. 수정이 필요하다면 하겠습니닷


## 스크린샷(UX의 경우 gif)
![스크린샷 2023-07-21 18 59 57](https://github.com/Bnomad-space/IAteIt/assets/70618615/921386a3-0687-4dc8-8325-7f987f8320a6)   ![스크린샷 2023-07-21 19 00 07](https://github.com/Bnomad-space/IAteIt/assets/70618615/daf29e42-de5d-4db9-b164-7d3dbcaa5867)
## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
