### PR TITLE
[Hotfix] EditProfileView에서도 username 알파벳 소문자 적용

### DIFF
--- a/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/EditProfileView.swift
@@ -96,7 +96,7 @@ struct EditProfileView: View {
                             .onChange(of: username) { _ in
                                 username = username.replacingOccurrences(of: " ", with: "")
                                 isValidFormat = testValidUsername(testString: username)
-                                isUnique = testUnique(testString: username)
+                                isUnique = testUnique(testString: username.lowercased())
                             }
                     }
                     Rectangle()
@@ -174,7 +174,7 @@ extension EditProfileView {
     }
     func saveProfile() {
         guard let userId = loginState.user?.id else { return }
-        var user = User(id: userId, nickname: self.username, profileImageUrl: loginState.user?.profileImageUrl)
+        var user = User(id: userId, nickname: self.username.lowercased(), profileImageUrl: loginState.user?.profileImageUrl)
         Task {
             if let image = selectedImage {
                 let newProfileImageUrl = try await FirebaseConnector.shared.uploadProfileImage(userId: userId, image: image)


### PR DESCRIPTION
## 관련 이슈들
- #89 

## 작업 내용
- 설정-프로필 수정 메뉴에서도 username 수정 시 소문자로 중복체크/수정 가능하도록 했습니다.

## 리뷰 노트
- 지난 PR에 누락되어 추가합니다..

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
