### PR TITLE
[Feat] #94 meal 삭제 시 comment도 있으면 삭제

### DIFF
--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -110,9 +110,20 @@ final class FeedMealModel: ObservableObject {
                 for plate in self.mealList[index].plates {
                     try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
                 }
+                if let commentList = self.commentList[mealId] {
+                    for comment in commentList {
+                        FirebaseConnector.shared.deleteComment(commentId: comment.id)
+                    }
+                } else if let commentList = self.myMealHistoryCommentList[mealId] {
+                    for comment in commentList {
+                        FirebaseConnector.shared.deleteComment(commentId: comment.id)
+                    }
+                }
             }
             DispatchQueue.main.async {
                 self.mealList.removeAll(where: { $0.id == mealId })
+                self.commentList[mealId]?.removeAll()
+                self.myMealHistoryCommentList[mealId]?.removeAll()
             }
         }
     }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -176,6 +176,7 @@ extension CameraView {
             meal.id = mealId
             meal.plates[0].mealId = mealId
             feedMeals.mealList.insert(meal, at: 0)
+            feedMeals.commentList[mealId] = []
         }
     }
     func saveAddPlate() {


### PR DESCRIPTION
## 관련 이슈들
- (ex. #2, #3 ...)

## 작업 내용
- meal 삭제 시 comment도 서버에서 삭제합니다.
- meal 업로드 후 바로 코멘트 작성하면 앱이 종료되는 문제가 있어 수정했습니다.

## 리뷰 노트
- meal 생성 코멘트 바로 달면 종료되는 문제를 meal 생성 시 commentList[mealId] 딕셔너리 value로 빈 배열 []을 먼저 넣어주도록 했는데 뭔가 임시방편스러운 것 같기도 하고.. 좋은 방법인지 모르겠습니다ㅜㅜ

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
