### PR TITLE
[hotfix] CameraView에서 시간 캡슐 보이는 것 삭제

### DIFF
--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -59,16 +59,6 @@ struct CameraView: View {
                         }
                     }
                     .padding(.bottom, 120)
-                    .overlay(
-                        Capsule()
-                            .foregroundColor(Color.black.opacity(0.6))
-                            .frame(width: 60, height: 28)
-                            .overlay(
-                                Text("\(currentTime, formatter: CameraView.dateFormat)")
-                                    .font(.footnote)
-                                    .foregroundColor(.white)
-                            )
-                            .padding(EdgeInsets(top: -230, leading: 290, bottom: 0, trailing: 0)))
                 // TODO: 기존 meal 포스팅의 캡션, 장소 위치잡기
                     .overlay {
                         VStack(alignment: .center, spacing: 6) {


### PR DESCRIPTION
## 관련 이슈들
- #96 

## 작업 내용
- 피드에서 보이는 사진에서는 시간 딱지 삭제했는데 카메라로 찍는 화면에는 삭제하는 것을 누락하여 삭제했습니다.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
