### PR TITLE
[Feat] 유저 차단 기능

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		040EB7332A55660D00E20A4D /* FirebaseConnector+ExtensionForReports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040EB7322A55660D00E20A4D /* FirebaseConnector+ExtensionForReports.swift */; };
 		040EB7352A55675600E20A4D /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040EB7342A55675600E20A4D /* ReportView.swift */; };
 		045339E72A0CAE59007F74F0 /* EmptyMealView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045339E62A0CAE59007F74F0 /* EmptyMealView.swift */; };
+		047121CD2A7D38E0004DCFC0 /* Block.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047121CC2A7D38E0004DCFC0 /* Block.swift */; };
+		047121CF2A7D396E004DCFC0 /* FirebaseConnector+ExtensionForBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047121CE2A7D396E004DCFC0 /* FirebaseConnector+ExtensionForBlocks.swift */; };
 		0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0487509A29B83DBD006836D1 /* FeedFooterView.swift */; };
 		048750A329B8A2D4006836D1 /* AddMealView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048750A229B8A2D4006836D1 /* AddMealView.swift */; };
 		048750A529B8ABA1006836D1 /* FeedTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048750A429B8ABA1006836D1 /* FeedTitleView.swift */; };
@@ -80,6 +82,8 @@
 		040EB7322A55660D00E20A4D /* FirebaseConnector+ExtensionForReports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseConnector+ExtensionForReports.swift"; sourceTree = "<group>"; };
 		040EB7342A55675600E20A4D /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		045339E62A0CAE59007F74F0 /* EmptyMealView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyMealView.swift; sourceTree = "<group>"; };
+		047121CC2A7D38E0004DCFC0 /* Block.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Block.swift; sourceTree = "<group>"; };
+		047121CE2A7D396E004DCFC0 /* FirebaseConnector+ExtensionForBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseConnector+ExtensionForBlocks.swift"; sourceTree = "<group>"; };
 		0487509A29B83DBD006836D1 /* FeedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedFooterView.swift; sourceTree = "<group>"; };
 		048750A229B8A2D4006836D1 /* AddMealView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddMealView.swift; sourceTree = "<group>"; };
 		048750A429B8ABA1006836D1 /* FeedTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTitleView.swift; sourceTree = "<group>"; };
@@ -294,6 +298,7 @@
 				DF883D4729B58F430029DC60 /* Comment.swift */,
 				DFD52CE329CB127D00E86F9F /* Meal.swift */,
 				040EB7302A5563B500E20A4D /* Report.swift */,
+				047121CC2A7D38E0004DCFC0 /* Block.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -423,6 +428,7 @@
 				7E48DC1B29F42F3E0079E896 /* FirebaseConnector+ExtensionForMeals.swift */,
 				7E48DC1D29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift */,
 				040EB7322A55660D00E20A4D /* FirebaseConnector+ExtensionForReports.swift */,
+				047121CE2A7D396E004DCFC0 /* FirebaseConnector+ExtensionForBlocks.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -523,6 +529,7 @@
 				8C73F00529BDDAE6007D1A1E /* DateFormatter.swift in Sources */,
 				04C1189329B74D6C0073EDB7 /* FeedHeaderView.swift in Sources */,
 				7E6069CD29A5CADE00284CBD /* SignUpView.swift in Sources */,
+				047121CD2A7D38E0004DCFC0 /* Block.swift in Sources */,
 				DF883D4829B58F430029DC60 /* Comment.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				045339E72A0CAE59007F74F0 /* EmptyMealView.swift in Sources */,
@@ -569,6 +576,7 @@
 				7E9FEF3929DF12EF002E7211 /* ImagePicker.swift in Sources */,
 				7E229BCD2A4AC31F009020BB /* PlateCountView.swift in Sources */,
 				DF2213A529BB324F000134FC /* FirebaseConnector.swift in Sources */,
+				047121CF2A7D396E004DCFC0 /* FirebaseConnector+ExtensionForBlocks.swift in Sources */,
 				7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/IAteIt/IAteIt/Model/Block.swift
+++ b/IAteIt/IAteIt/Model/Block.swift
@@ -1,0 +1,14 @@
+//
+//  Block.swift
+//  IAteIt
+//
+//  Created by Beone on 2023/08/04.
+//
+
+import Foundation
+
+struct Block: Identifiable, Codable, Hashable {
+    let id: String
+    var Blocker_id: String
+    var Blocked_id: String
+}

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForBlocks.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForBlocks.swift
@@ -1,0 +1,78 @@
+//
+//  FirebaseConnector+ExtensionForBlocks.swift
+//  IAteIt
+//
+//  Created by Beone on 2023/08/04.
+//
+
+import Firebase
+import FirebaseFirestore
+import SwiftUI
+
+extension FirebaseConnector {
+    static let blocks = Firestore.firestore().collection("blocks")
+    
+    func setBlock(Blocker_id: String, Blocked_id: String) {
+        let block = Block(
+            id: UUID().uuidString,
+            Blocker_id: Blocker_id,
+            Blocked_id: Blocked_id
+        )
+        
+        do {
+            let documentData = try Firestore.Encoder().encode(block)
+            FirebaseConnector.blocks.document(block.id).setData(documentData) { error in
+                if let error = error {
+                    print("Failed to set block: \(error.localizedDescription)")
+                } else {
+                    print("block sent successfully!")
+                }
+            }
+        } catch {
+            print("Error encoding block: \(error.localizedDescription)")
+        }
+    }
+
+//    func fetchBlocksByBlockerId(blockerId: String, completion: @escaping ([Block]?, Error?) -> Void) {
+//        FirebaseConnector.blocks
+//            .whereField("blocker_id", isEqualTo: blockerId)
+//            .getDocuments { snapshot, error in
+//                if let error = error {
+//                    completion(nil, error)
+//                    return
+//                }
+//
+//                var blocks: [Block] = []
+//                for document in snapshot?.documents ?? [] {
+//                    do {
+//                        let blockData = try document.data(as: Block.self)
+//                        blocks.append(blockData)
+//                    } catch {
+//                        completion(nil, error)
+//                        return
+//                    }
+//                }
+//
+//                completion(blocks, nil)
+//            }
+//    }
+    
+    func fetchBlocksByBlockerId(blockerId: String) async throws -> [String] {
+        var blocks: [String] = []
+        
+        FirebaseConnector.blocks.whereField("blocker_id", isEqualTo: blockerId)
+            .getDocuments() { (snapshot, error) in
+                if let error = error {
+                    print("Error getting documents: \(error)")
+                } else {
+                    for document in snapshot?.documents ?? [] {
+                        let blockData = document.data()
+                        guard let blocked_id = blockData["blocked_id"] as? String else {return}
+                        blocks.append(blocked_id)
+                    }
+                }
+            }
+        return blocks
+    }
+    
+}

--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForBlocks.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForBlocks.swift
@@ -32,47 +32,24 @@ extension FirebaseConnector {
             print("Error encoding block: \(error.localizedDescription)")
         }
     }
-
-//    func fetchBlocksByBlockerId(blockerId: String, completion: @escaping ([Block]?, Error?) -> Void) {
-//        FirebaseConnector.blocks
-//            .whereField("blocker_id", isEqualTo: blockerId)
-//            .getDocuments { snapshot, error in
-//                if let error = error {
-//                    completion(nil, error)
-//                    return
-//                }
-//
-//                var blocks: [Block] = []
-//                for document in snapshot?.documents ?? [] {
-//                    do {
-//                        let blockData = try document.data(as: Block.self)
-//                        blocks.append(blockData)
-//                    } catch {
-//                        completion(nil, error)
-//                        return
-//                    }
-//                }
-//
-//                completion(blocks, nil)
-//            }
-//    }
     
     func fetchBlocksByBlockerId(blockerId: String) async throws -> [String] {
         var blocks: [String] = []
         
-        FirebaseConnector.blocks.whereField("blocker_id", isEqualTo: blockerId)
-            .getDocuments() { (snapshot, error) in
-                if let error = error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    for document in snapshot?.documents ?? [] {
-                        let blockData = document.data()
-                        guard let blocked_id = blockData["blocked_id"] as? String else {return}
-                        blocks.append(blocked_id)
-                    }
+        do {
+            let querySnapshot = try await FirebaseConnector.blocks.whereField("Blocker_id", isEqualTo: blockerId).getDocuments()
+            
+            for document in querySnapshot.documents {
+                let blockData = document.data()
+                if let blockedId = blockData["Blocked_id"] as? String {
+                    blocks.append(blockedId)
                 }
             }
-        return blocks
+            
+            print("DEBUG at fetch: ", blocks)
+            return blocks
+        } catch {
+            throw error
+        }
     }
-    
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -77,6 +77,9 @@ struct FeedView: View {
         .refreshable {
           do {
             try await Task.sleep(nanoseconds: 1_000_000_000)
+              if let user = loginState.user {
+                  feedMeals.getBlockedUserId(user: user)
+              }
               feedMeals.refreshMealsAndUsers()
           } catch {print("Error refreshing data: \(error)")}
         }

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -16,6 +16,7 @@ final class FeedMealModel: ObservableObject {
     }
     @Published var allUsers: [User] = []
     @Published var commentList: [String: [Comment]] = [:]
+    @Published var blockedUserList: [String] = []
     
     @Published var myMealHistory: [Meal] = []
     @Published var myMealHistoryCommentList: [String: [Comment]] = [:]
@@ -23,6 +24,12 @@ final class FeedMealModel: ObservableObject {
 
     init() {
         self.refreshMealsAndUsers()
+    }
+    
+    func getBlockedUserId(user: User) {
+        Task {
+            self.blockedUserList = try await FirebaseConnector().fetchBlocksByBlockerId(blockerId: user.id)
+        }
     }
     
     @MainActor

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -39,6 +39,12 @@ final class FeedMealModel: ObservableObject {
     func getMealListIn24Hours() {
         Task {
             self.mealList = try await FirebaseConnector.shared.fetchMealIn24Hours(date: Date())
+            for i in stride(from: self.mealList.count - 1, through: 0, by: -1) {
+                let eachMeal = self.mealList[i]
+                if blockedUserList.contains(eachMeal.userId) {
+                    self.mealList.remove(at: i)
+                }
+            }
             for meal in self.mealList {
                 FirebaseConnector.shared.fetchMealComments(mealId: meal.id!) { comments in
                     self.commentList[meal.id!] = comments
@@ -144,14 +150,7 @@ final class FeedMealModel: ObservableObject {
             await MainActor.run {
                 self.allUsers = fetchAllUser
                 self.getMealListIn24Hours()
-                print("DEBUG at regrashfunc:", self.blockedUserList)
-                for i in stride(from: self.mealList.count - 1, through: 0, by: -1) {
-                    let eachMeal = self.mealList[i]
-                    if blockedUserList.contains(eachMeal.userId) {
-                        self.mealList.remove(at: i)
-                    }
-                }
-            }
+                print("DEBUG at regrashfunc:", self.blockedUserList)            }
         }
     }
 

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -23,12 +23,15 @@ final class FeedMealModel: ObservableObject {
     @Published var myMealHistorySorted: [(key: String, value: [Meal])] = []
 
     init() {
+        print("DEBUGG at init:", self.blockedUserList)
         self.refreshMealsAndUsers()
     }
     
+    @MainActor
     func getBlockedUserId(user: User) {
         Task {
             self.blockedUserList = try await FirebaseConnector().fetchBlocksByBlockerId(blockerId: user.id)
+            print("DEBUG at getBlockedUserId:", self.blockedUserList)
         }
     }
     
@@ -141,6 +144,13 @@ final class FeedMealModel: ObservableObject {
             await MainActor.run {
                 self.allUsers = fetchAllUser
                 self.getMealListIn24Hours()
+                print("DEBUG at regrashfunc:", self.blockedUserList)
+                for i in stride(from: self.mealList.count - 1, through: 0, by: -1) {
+                    let eachMeal = self.mealList[i]
+                    if blockedUserList.contains(eachMeal.userId) {
+                        self.mealList.remove(at: i)
+                    }
+                }
             }
         }
     }

--- a/IAteIt/IAteIt/View/MealDetail/Component/ReportView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/Component/ReportView.swift
@@ -55,7 +55,7 @@ struct ReportView: View {
                 .clipped()
                 .cornerRadius(photoCorner)
                 
-                TextField("Please tell us why you are reporting this meal.", text: $text)
+                TextField("Please provide the reason for reporting.", text: $text)
                     .frame(height: 100)
                     .textFieldStyle(.plain)
                     .padding(.horizontal)

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -146,7 +146,9 @@ struct MealDetailView: View {
         })
         .alert("Blocking this user", isPresented: $isBlockingAlertPresented, actions: {
             Button("Block", role: .destructive, action: {
-                FirebaseConnector().setBlock(Blocker_id: user.id, Blocked_id: meal.userId)
+                if let blocker = loginState.user {
+                    FirebaseConnector().setBlock(Blocker_id: blocker.id, Blocked_id: meal.userId)
+                }
             })
             Button("Cancel", role: .cancel, action: {})
         }, message: {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -20,6 +20,7 @@ struct MealDetailView: View {
     @State private var isShowingMealDeleteAlert = false
     @State private var isShowingPlateDeleteAlert = false
     @State private var isReportPresented = false
+    @State private var isBlockingAlertPresented = false
     
     var meal: Meal
     var user: User
@@ -143,6 +144,14 @@ struct MealDetailView: View {
         }, message: {
             Text("This action is irreversible.")
         })
+        .alert("Blocking this user", isPresented: $isBlockingAlertPresented, actions: {
+            Button("Block", role: .destructive, action: {
+                FirebaseConnector().setBlock(Blocker_id: user.id, Blocked_id: meal.userId)
+            })
+            Button("Cancel", role: .cancel, action: {})
+        }, message: {
+            Text("Blocked users won't be able to see your posts, and their posts won't appear on your feed..")
+        })
         .sheet(isPresented: $isReportPresented) {
             ReportView(meal: meal, user: user, isReportPresented: $isReportPresented)
                     .environmentObject(loginState)
@@ -161,6 +170,11 @@ struct MealDetailView: View {
                                     isReportPresented = true
                                 }, label: {
                                     Label("Report this meal", systemImage: "exclamationmark.triangle")
+                                })
+                                Button(role: .destructive, action: {
+                                    isBlockingAlertPresented = true
+                                }, label: {
+                                    Label("Block this user", systemImage: "nosign")
                                 })
                         }
                     }, label: {


### PR DESCRIPTION
## 관련 이슈들
- #102 

## 작업 내용
- 유저 차단 UI와 기능을 일부 구현했습니다.
- 수정이 필요합니다.

## 리뷰 노트
- 현재는 피드에서 새로고침을 해야만 차단한 유저의 게시물이 지워집니다.
- loginState의 유저정보를 feedMealModel에서 사용해야 하기 때문에 차단목록을 fetch하는 로직을 새로고침에 넣어둔건데, 애초에 로드할때부터 feedMealModel이 user 정보를 받아오게 하려면 어떻게 해야 하는지 모르겠습니다 ㅜㅜ 구현완료되면 pr 수정하겠습니다
- block 구조가 Blocker_id, Blocked_id 쌍의 필드로 되어있는데, 이걸 전부 받아와서 feed 안에서 다시 처리할까 생각중입니다

## 스크린샷(UX의 경우 gif)
![스크린샷 2023-08-05 14 01 07](https://github.com/Bnomad-space/IAteIt/assets/70618615/25ce4ef0-93b7-4f82-93d0-776fe99adfab)

## Reference
- 참고한 사이트, 정리한 링크를 달아주세요.

## 체크리스트
- [ ] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [ ] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [ ] 불필요한 주석과 프린트문은 삭제가 되었나요?
