### PR TITLE
[Feat] #101 Setting 메뉴 추가, Blocked Users 메뉴 기능 구현

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */; };
 		7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */; };
 		7E7385302A77D1800010CA32 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */; };
+		7E7385502A7B6A920010CA32 /* BlockedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */; };
 		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
 		7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */; };
 		7E9FEF3529DEA07A002E7211 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF3429DEA07A002E7211 /* BottomButtonView.swift */; };
@@ -117,6 +118,7 @@
 		7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardView.swift; sourceTree = "<group>"; };
 		7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOnPhotoView.swift; sourceTree = "<group>"; };
 		7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersView.swift; sourceTree = "<group>"; };
 		7E9198A229CF56B400044815 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		7E9198A429CF591200044815 /* IAteIt.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IAteIt.entitlements; sourceTree = "<group>"; };
 		7E9FEF3129DE9BFA002E7211 /* TextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+Extension.swift"; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				7E407CDA2A0E6608001CAFBF /* EditProfileView.swift */,
+				7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -540,6 +543,7 @@
 				630BA6C029AF57BE00019F2E /* Camera.swift in Sources */,
 				630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */,
 				46F06E3F2A176357009E3603 /* MealTileView.swift in Sources */,
+				7E7385502A7B6A920010CA32 /* BlockedUsersView.swift in Sources */,
 				7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */,
 				04C1189029B74BF40073EDB7 /* FeedView.swift in Sources */,
 				7E407CD22A0BEBEF001CAFBF /* AddPlateButtonView.swift in Sources */,

--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069DF29A7A7B400284CBD /* CommentView.swift */; };
 		7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */; };
 		7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */; };
+		7E6528952A944BAD004F466B /* BlockedUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6528942A944BAD004F466B /* BlockedUserView.swift */; };
 		7E7385302A77D1800010CA32 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */; };
 		7E7385502A7B6A920010CA32 /* BlockedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */; };
 		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
@@ -117,6 +118,7 @@
 		7E6069DF29A7A7B400284CBD /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardView.swift; sourceTree = "<group>"; };
 		7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOnPhotoView.swift; sourceTree = "<group>"; };
+		7E6528942A944BAD004F466B /* BlockedUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserView.swift; sourceTree = "<group>"; };
 		7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersView.swift; sourceTree = "<group>"; };
 		7E9198A229CF56B400044815 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 			isa = PBXGroup;
 			children = (
 				7E407CDD2A0F538C001CAFBF /* SettingListTitleView.swift */,
+				7E6528942A944BAD004F466B /* BlockedUserView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -541,6 +544,7 @@
 				7E6069CF29A5CAE500284CBD /* CameraView.swift in Sources */,
 				8C73F00E29E1291A007D1A1E /* ProfileCellView.swift in Sources */,
 				630BA6C029AF57BE00019F2E /* Camera.swift in Sources */,
+				7E6528952A944BAD004F466B /* BlockedUserView.swift in Sources */,
 				630BA6C229AF57F700019F2E /* CameraViewModel.swift in Sources */,
 				46F06E3F2A176357009E3603 /* MealTileView.swift in Sources */,
 				7E7385502A7B6A920010CA32 /* BlockedUsersView.swift in Sources */,

--- a/IAteIt/IAteIt/Model/User.swift
+++ b/IAteIt/IAteIt/Model/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct User: Identifiable, Codable {
+struct User: Identifiable, Codable, Hashable {
     let id: String
     var nickname: String // Eng only, Must be unique, no blank space
     var profileImageUrl: String? // profileImageUrl nil이라면, systemName으로 Image 넣어주어야 함

--- a/IAteIt/IAteIt/Network/FirebaseConnector.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector.swift
@@ -112,6 +112,13 @@ final class FirebaseConnector {
             .updateData(["blockedId": FieldValue.arrayUnion([BlockedId])])
     }
     
+    // 특정 user 차단정보 삭제
+    func deleteBlockedId(user: User, blockedId: String) async throws {
+        try await FirebaseConnector.users.document(user.id)
+            .updateData([
+                "blockedId": FieldValue.arrayRemove([blockedId])
+            ])
+    }
     
     // user 데이터 가져오기
     func fetchUser(id: String) async throws -> User {

--- a/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
+++ b/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct BlockedUserView: View {
+    @EnvironmentObject var loginState: LoginStateModel
+    
     let profilePicSize: CGFloat = 36
     var user: User
     
@@ -47,7 +49,7 @@ struct BlockedUserView: View {
             Spacer()
             
             Button(action: {
-                
+                loginState.deleteBlockedUser(blockedUser: user)
             }, label: {
                 Image(systemName: "xmark")
                     .foregroundColor(Color(UIColor.systemGray2))

--- a/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
+++ b/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
@@ -1,0 +1,63 @@
+//
+//  BlockedUserView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/08/22.
+//
+
+import SwiftUI
+
+struct BlockedUserView: View {
+    let profilePicSize: CGFloat = 36
+    var user: User
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            if let userImage = user.profileImageUrl {
+                CacheAsyncImage(url: URL(string: userImage)!) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .circleImage(imageSize: profilePicSize)
+                    case .failure(_):
+                        Image(systemName: "exclamationmark.circle")
+                            .circleImage(imageSize: profilePicSize)
+                    case .empty:
+                        Color(UIColor.systemGray6)
+                            .frame(width: profilePicSize, height: profilePicSize)
+                            .clipShape(Circle())
+                    @unknown default:
+                        Image(systemName: "person.crop.circle")
+                            .resizable()
+                            .circleImage(imageSize: profilePicSize)
+                            .foregroundColor(Color(UIColor.systemGray3))
+                    }
+                }
+            } else {
+                Image(systemName: "person.crop.circle")
+                    .resizable()
+                    .frame(width: profilePicSize, height: profilePicSize)
+                    .foregroundColor(Color(UIColor.systemGray3))
+            }
+            
+            Text(user.nickname)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            
+            Spacer()
+            
+            Button(action: {
+                
+            }, label: {
+                Image(systemName: "xmark")
+                    .foregroundColor(Color(UIColor.systemGray2))
+            })
+        }
+    }
+}
+
+struct BlockedUserView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockedUserView(user: User.users[0])
+    }
+}

--- a/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
@@ -8,17 +8,30 @@
 import SwiftUI
 
 struct BlockedUsersView: View {
-    
+    @EnvironmentObject var loginState: LoginStateModel
     
     var body: some View {
-        VStack(alignment: .center){
-            Text("There are no blocked users.")
-                .font(.body)
-                .foregroundColor(.gray)
+        VStack {
+            if let blockedId = loginState.user?.blockedId {
+                ForEach(loginState.blockedUsers, id:\.self) { blockedUser in
+                    BlockedUserView(user: blockedUser)
+                }
+            } else {
+                VStack(alignment: .center){
+                    Text("There are no blocked users.")
+                        .font(.body)
+                        .foregroundColor(.gray)
+                        .padding(.top, 24)
+                    Spacer()
+                }
+            }
         }
         .navigationTitle("Blocked Users")
-        
-        
+        .onAppear {
+            if let blockedId = loginState.user?.blockedId {
+                loginState.fetchBlockedUsers(blockedIdList: blockedId)
+            }
+        }
     }
 }
 

--- a/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
@@ -1,0 +1,29 @@
+//
+//  BlockedUsersView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/08/03.
+//
+
+import SwiftUI
+
+struct BlockedUsersView: View {
+    
+    
+    var body: some View {
+        VStack(alignment: .center){
+            Text("There are no blocked users.")
+                .font(.body)
+                .foregroundColor(.gray)
+        }
+        .navigationTitle("Blocked Users")
+        
+        
+    }
+}
+
+struct BlockedUsersView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlockedUsersView()
+    }
+}

--- a/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
+++ b/IAteIt/IAteIt/View/Setting/Menu/BlockedUsersView.swift
@@ -11,25 +11,30 @@ struct BlockedUsersView: View {
     @EnvironmentObject var loginState: LoginStateModel
     
     var body: some View {
-        VStack {
-            if let blockedId = loginState.user?.blockedId {
-                ForEach(loginState.blockedUsers, id:\.self) { blockedUser in
-                    BlockedUserView(user: blockedUser)
-                }
-            } else {
-                VStack(alignment: .center){
-                    Text("There are no blocked users.")
-                        .font(.body)
-                        .foregroundColor(.gray)
-                        .padding(.top, 24)
-                    Spacer()
+        ScrollView {
+            VStack {
+                if loginState.blockedUsers.count > 0 {
+                    ForEach(loginState.blockedUsers, id:\.self) { blockedUser in
+                        BlockedUserView(user: blockedUser)
+                            .environmentObject(loginState)
+                    }
+                } else {
+                    VStack(alignment: .center){
+                        Text("There are no blocked users.")
+                            .font(.body)
+                            .foregroundColor(.gray)
+                            .padding(.top, 24)
+                        Spacer()
+                    }
                 }
             }
-        }
-        .navigationTitle("Blocked Users")
-        .onAppear {
-            if let blockedId = loginState.user?.blockedId {
-                loginState.fetchBlockedUsers(blockedIdList: blockedId)
+            .padding(.top, .paddingHorizontal)
+            .padding(.horizontal, .paddingHorizontal)
+            .navigationTitle("Blocked Users")
+            .onAppear {
+                if let blockedId = loginState.user?.blockedId {
+                    loginState.fetchBlockedUsers(blockedIdList: blockedId)
+                }
             }
         }
     }

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -16,12 +16,30 @@ struct SettingView: View {
     
     var body: some View {
         List {
-            Section {
+            Section(header: Text("Personal")) {
                 NavigationLink(destination: {
                     EditProfileView()
                         .environmentObject(loginState)
                 }, label: {
                     SettingListTitleView(text: "Edit Profile", symbol: "person", color: .black)
+                })
+                NavigationLink(destination: {
+                    BlockedUsersView()
+                        .environmentObject(loginState)
+                }, label: {
+                    SettingListTitleView(text: "Blocked Users", symbol: "nosign", color: .black)
+                })
+            }
+            Section(header: Text("Information")) {
+                Button(action: {
+                    
+                }, label: {
+                    SettingListTitleView(text: "Terms of Use", symbol: "doc.text", color: .black)
+                })
+                Button(action: {
+                    
+                }, label: {
+                    SettingListTitleView(text: "Privacy Policy", symbol: "lock.doc", color: .black)
                 })
             }
             Section(header: Text("Dangerous Area")) {

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -20,6 +20,7 @@ class LoginStateModel: ObservableObject {
     @Published var isDeleteAccountCompleteAlertRequired = false
     @Published var isShowingDeleteAccountCompleteAlert = false
     @Published var type = types.createAccount
+    @Published var blockedUsers: [User] = []
     
     enum types {
         case createAccount
@@ -162,6 +163,18 @@ class LoginStateModel: ObservableObject {
             } catch {
                 print("error deleting user: \(error)")
             }
+        }
+    }
+    
+    func fetchBlockedUsers(blockedIdList: [String]) {
+        Task {
+            var userList: [User] = []
+            
+            for id in blockedIdList {
+                let fetchedUser = try await FirebaseConnector.shared.fetchUser(id: id)
+                userList.append(fetchedUser)
+            }
+            self.blockedUsers = userList
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈들
- #101 

## 작업 내용
- Setting 화면에 메뉴를 추가했습니다. - blocked users, terms of use, privacy policy
- blocked users 메뉴에서 차단한 유저를 삭제하는 기능을 구현했습니다.


## 스크린샷(UX의 경우 gif)
<p list="left">

<img width="300" alt="Screenshot 2023-08-23 at 2 04 26 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/982e5e30-ac47-4b4f-a777-6174ae1a1458">

<img width="300" alt="Screenshot 2023-08-23 at 2 04 56 PM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/f865a6a8-54bb-4e4e-b035-f76ea186cc79">
</p>


## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
