### PR TITLE
[hotfix] BlockedUserView 프로필 이미지 수정

### DIFF
--- a/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
+++ b/IAteIt/IAteIt/View/Setting/Component/BlockedUserView.swift
@@ -6,9 +6,11 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct BlockedUserView: View {
     @EnvironmentObject var loginState: LoginStateModel
+    @State private var error: KingfisherError?
     
     let profilePicSize: CGFloat = 36
     var user: User
@@ -16,30 +18,17 @@ struct BlockedUserView: View {
     var body: some View {
         HStack(spacing: 12) {
             if let userImage = user.profileImageUrl {
-                CacheAsyncImage(url: URL(string: userImage)!) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .circleImage(imageSize: profilePicSize)
-                    case .failure(_):
-                        Image(systemName: "exclamationmark.circle")
-                            .circleImage(imageSize: profilePicSize)
-                    case .empty:
-                        Color(UIColor.systemGray6)
-                            .frame(width: profilePicSize, height: profilePicSize)
-                            .clipShape(Circle())
-                    @unknown default:
-                        Image(systemName: "person.crop.circle")
-                            .resizable()
-                            .circleImage(imageSize: profilePicSize)
-                            .foregroundColor(Color(UIColor.systemGray3))
+                KFImage.url(URL(string: userImage)!)
+                    .onFailure { error in
+                        self.error = error
                     }
-                }
+                    .placeholder {
+                        ProfileImageErrorView(error: $error, size: profilePicSize)
+                    }
+                    .cancelOnDisappear(true)
+                    .circleImage(imageSize: profilePicSize)
             } else {
-                Image(systemName: "person.crop.circle")
-                    .resizable()
-                    .frame(width: profilePicSize, height: profilePicSize)
-                    .foregroundColor(Color(UIColor.systemGray3))
+                ProfileImageDefaultView(size: profilePicSize)
             }
             
             Text(user.nickname)


### PR DESCRIPTION
## 작업 내용
- BlockedUserView의 프로필 이미지에 킹피셔 적용이 안되어있어 수정했습니다.

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
