### PR TITLE
[feat] #108 terms of use, privacy policy 추가

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		7E229BD12A5DC414009020BB /* InnerShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E229BD02A5DC414009020BB /* InnerShadowModifier.swift */; };
 		7E229BD32A5DCA45009020BB /* PlateImageErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E229BD22A5DCA45009020BB /* PlateImageErrorView.swift */; };
 		7E2B2DAD29DE9304009EC0ED /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2B2DAC29DE9304009EC0ED /* Constants.swift */; };
+		7E2E84EA2AA77B960056D007 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2E84E92AA77B960056D007 /* WebView.swift */; };
 		7E407CCC2A044D1B001CAFBF /* FeedMealModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E407CCB2A044D1B001CAFBF /* FeedMealModel.swift */; };
 		7E407CCE2A04F682001CAFBF /* AuthDataResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E407CCD2A04F682001CAFBF /* AuthDataResultModel.swift */; };
 		7E407CD02A0558A3001CAFBF /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7E407CCF2A0558A3001CAFBF /* FirebaseFirestoreSwift */; };
@@ -48,10 +49,10 @@
 		7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069DF29A7A7B400284CBD /* CommentView.swift */; };
 		7E6069E229A7A7FE00284CBD /* PhotoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */; };
 		7E6069E429A7ADE100284CBD /* TagOnPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */; };
+		7E6528952A944BAD004F466B /* BlockedUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6528942A944BAD004F466B /* BlockedUserView.swift */; };
 		7E6528CB2A9AE114004F466B /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 7E6528CA2A9AE114004F466B /* Kingfisher */; };
 		7E6528CF2A9AE434004F466B /* ProfileImageErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6528CE2A9AE434004F466B /* ProfileImageErrorView.swift */; };
 		7E6528D12A9AF39D004F466B /* ProfileImageDefaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6528D02A9AF39D004F466B /* ProfileImageDefaultView.swift */; };
-		7E6528952A944BAD004F466B /* BlockedUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6528942A944BAD004F466B /* BlockedUserView.swift */; };
 		7E7385302A77D1800010CA32 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */; };
 		7E7385502A7B6A920010CA32 /* BlockedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */; };
 		7E9198A329CF56B400044815 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9198A229CF56B400044815 /* LoginView.swift */; };
@@ -101,6 +102,7 @@
 		7E229BD02A5DC414009020BB /* InnerShadowModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerShadowModifier.swift; sourceTree = "<group>"; };
 		7E229BD22A5DCA45009020BB /* PlateImageErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlateImageErrorView.swift; sourceTree = "<group>"; };
 		7E2B2DAC29DE9304009EC0ED /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		7E2E84E92AA77B960056D007 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		7E407CCB2A044D1B001CAFBF /* FeedMealModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedMealModel.swift; sourceTree = "<group>"; };
 		7E407CCD2A04F682001CAFBF /* AuthDataResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataResultModel.swift; sourceTree = "<group>"; };
 		7E407CD12A0BEBEF001CAFBF /* AddPlateButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPlateButtonView.swift; sourceTree = "<group>"; };
@@ -119,9 +121,9 @@
 		7E6069DF29A7A7B400284CBD /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		7E6069E129A7A7FE00284CBD /* PhotoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCardView.swift; sourceTree = "<group>"; };
 		7E6069E329A7ADE100284CBD /* TagOnPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagOnPhotoView.swift; sourceTree = "<group>"; };
+		7E6528942A944BAD004F466B /* BlockedUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserView.swift; sourceTree = "<group>"; };
 		7E6528CE2A9AE434004F466B /* ProfileImageErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageErrorView.swift; sourceTree = "<group>"; };
 		7E6528D02A9AF39D004F466B /* ProfileImageDefaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageDefaultView.swift; sourceTree = "<group>"; };
-		7E6528942A944BAD004F466B /* BlockedUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserView.swift; sourceTree = "<group>"; };
 		7E73852F2A77D1800010CA32 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7E73854F2A7B6A920010CA32 /* BlockedUsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersView.swift; sourceTree = "<group>"; };
 		7E9198A229CF56B400044815 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 				7E9FEF3829DF12EF002E7211 /* ImagePicker.swift */,
 				7E2B2DAC29DE9304009EC0ED /* Constants.swift */,
 				7E229BD02A5DC414009020BB /* InnerShadowModifier.swift */,
+				7E2E84E92AA77B960056D007 /* WebView.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -542,6 +545,7 @@
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				045339E72A0CAE59007F74F0 /* EmptyMealView.swift in Sources */,
 				8C73F00329BDD010007D1A1E /* MealListView.swift in Sources */,
+				7E2E84EA2AA77B960056D007 /* WebView.swift in Sources */,
 				7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */,
 				8C73F00329BDD010007D1A1E /* MealListView.swift in Sources */,
 				7E48DC2529F93E1F0079E896 /* LoginStateModel.swift in Sources */,

--- a/IAteIt/IAteIt/Utility/Constants.swift
+++ b/IAteIt/IAteIt/Utility/Constants.swift
@@ -10,3 +10,10 @@ import Foundation
 extension CGFloat {
     public static let paddingHorizontal: CGFloat = 16
 }
+
+enum Const {
+    enum URL: String {
+        case termsOfUse = "https://riverisrain.notion.site/Terms-of-Use-c64b2e6ce02141adbef48945f8eeb4b6?pvs=4"
+        case privacyPolicy = "https://riverisrain.notion.site/Privacy-Policy-117649cb425443eba0caae331c4b585a?pvs=4"
+    }
+}

--- a/IAteIt/IAteIt/Utility/WebView.swift
+++ b/IAteIt/IAteIt/Utility/WebView.swift
@@ -1,0 +1,24 @@
+//
+//  WebView.swift
+//  IAteIt
+//
+//  Created by Eunbee Kang on 2023/09/06.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    let url: URL
+    
+    func makeUIView(context: Context) -> WKWebView {
+
+        return WKWebView()
+    }
+    
+    func updateUIView(_ webView: WKWebView, context: Context) {
+
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+}

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -11,7 +11,8 @@ struct SettingView: View {
     @EnvironmentObject var loginState: LoginStateModel
     @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isShowingDeleteAccountAlert = false
-    @State private var isPresentWebView = false
+    @State private var isPresentTermsOfUseWebView = false
+    @State private var isPresentPrivacyPolicyWebView = false
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
     
@@ -33,11 +34,11 @@ struct SettingView: View {
             }
             Section(header: Text("Information")) {
                 Button(action: {
-                    isPresentWebView = true
+                    isPresentTermsOfUseWebView = true
                 }, label: {
                     SettingListTitleView(text: "Terms of Use", symbol: "doc.text", color: .black)
                 })
-                .sheet(isPresented: $isPresentWebView) {
+                .sheet(isPresented: $isPresentTermsOfUseWebView) {
                     NavigationView {
                         WebView(url: URL(string: Const.URL.termsOfUse.rawValue)!)
                             .navigationTitle("Terms of Use")
@@ -45,11 +46,11 @@ struct SettingView: View {
                     }
                 }
                 Button(action: {
-                    isPresentWebView = true
+                    isPresentPrivacyPolicyWebView = true
                 }, label: {
                     SettingListTitleView(text: "Privacy Policy", symbol: "lock.doc", color: .black)
                 })
-                .sheet(isPresented: $isPresentWebView) {
+                .sheet(isPresented: $isPresentPrivacyPolicyWebView) {
                     NavigationView {
                         WebView(url: URL(string: Const.URL.privacyPolicy.rawValue)!)
                             .navigationTitle("Privacy Policy")

--- a/IAteIt/IAteIt/View/Setting/SettingView.swift
+++ b/IAteIt/IAteIt/View/Setting/SettingView.swift
@@ -11,6 +11,7 @@ struct SettingView: View {
     @EnvironmentObject var loginState: LoginStateModel
     @EnvironmentObject var feedMeals: FeedMealModel
     @State private var isShowingDeleteAccountAlert = false
+    @State private var isPresentWebView = false
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @Environment(\.rootPresentationMode) private var rootPresentationMode: Binding<RootPresentationMode>
     
@@ -32,15 +33,29 @@ struct SettingView: View {
             }
             Section(header: Text("Information")) {
                 Button(action: {
-                    
+                    isPresentWebView = true
                 }, label: {
                     SettingListTitleView(text: "Terms of Use", symbol: "doc.text", color: .black)
                 })
+                .sheet(isPresented: $isPresentWebView) {
+                    NavigationView {
+                        WebView(url: URL(string: Const.URL.termsOfUse.rawValue)!)
+                            .navigationTitle("Terms of Use")
+                            .navigationBarTitleDisplayMode(.inline)
+                    }
+                }
                 Button(action: {
-                    
+                    isPresentWebView = true
                 }, label: {
                     SettingListTitleView(text: "Privacy Policy", symbol: "lock.doc", color: .black)
                 })
+                .sheet(isPresented: $isPresentWebView) {
+                    NavigationView {
+                        WebView(url: URL(string: Const.URL.privacyPolicy.rawValue)!)
+                            .navigationTitle("Privacy Policy")
+                            .navigationBarTitleDisplayMode(.inline)
+                    }
+                }
             }
             Section(header: Text("Dangerous Area")) {
                 Button(action: {

--- a/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
+++ b/IAteIt/IAteIt/View/SignUp/SignUpSecondView.swift
@@ -49,20 +49,31 @@ struct SignUpSecondView: View {
             .shadow(color: .black.opacity(0.20), radius: 10, x: 4, y: 4)
             .padding(.top, 40)
             
-            Spacer()
             if isLaterTextPresented {
                 Text("You can do this later!")
                     .font(.body)
                     .foregroundColor(Color(UIColor.systemGray))
-                    .padding(.bottom, 20)
+                    .padding(.top, 32)
             }
-            Button(action: {
-                saveAndCompleteSignUp()
-            }, label: {
-                BottomButtonView(label: "Done")
-            })
+            Spacer()
         }
         .navigationBarHidden(true)
+        .overlay {
+            VStack {
+                Spacer()
+                Text("By tapping ‘Done’, you agree to our [Terms of Use](https://riverisrain.notion.site/Terms-of-Use-c64b2e6ce02141adbef48945f8eeb4b6?pvs=4)) and [Privacy Policy](https://riverisrain.notion.site/Privacy-Policy-117649cb425443eba0caae331c4b585a?pvs=4).")
+                    .font(.footnote)
+                    .foregroundColor(Color(UIColor.systemGray))
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 36)
+                
+                Button(action: {
+                    saveAndCompleteSignUp()
+                }, label: {
+                    BottomButtonView(label: "Done")
+                })
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 관련 이슈들
- #108 

## 작업 내용
이용약관, 개인정보 처리방침을 아래와 같이 확인할 수 있습니다.
- 회원가입 완료 전 Done 버튼 상단 문구
- Settings 메뉴

## 리뷰 노트
- 회원가입 화면에 잘 나오는지 확인하려고 jedong 계정삭제 하려는데 에러가 나는걸 이제 확인했습니다... 7월쯤 meals 저장 구조 날짜별로 바꾸면서 컬렉션 쿼리 사용을 위해 firestore 규칙을 수정했었는데 영향이 있었던 것 같습니다ㅠ_ㅠ

## 스크린샷(UX의 경우 gif)
<p list="left">
<img width="300" alt="Screenshot 2023-09-06 at 12 35 18 AM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/5d40df91-ad55-4df8-acea-8cb0ac489148">
<img width="300" alt="Screenshot 2023-09-06 at 12 39 59 AM" src="https://github.com/Bnomad-space/IAteIt/assets/103012157/e7733735-6fcd-4d78-a3f2-6d80e245b8c6">
</p>

## Reference
- [WebView in SwiftUI](https://sarunw.com/posts/swiftui-webview/)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
