### PR TITLE
[Bug] BlockedId 필드 없으면 Feed 안보이는 문제 해결, Firestore 보안 규칙 작성

### DIFF
--- a/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
+++ b/IAteIt/IAteIt/Network/FirebaseConnector+ExtensionForMeals.swift
@@ -108,7 +108,7 @@ extension FirebaseConnector {
     // 24시간 이내 업로드된 모든 meal 데이터 가져오기
     func fetchMealIn24Hours(date: Date) async throws -> [Meal] {
         var meals: [Meal] = []
-
+        
         let toTime = date
         let toTimestamp = Timestamp(date: toTime)
         let fromTime = date-3600*24

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -18,14 +18,14 @@ struct FeedView: View {
     
     var body: some View {
         ScrollView(showsIndicators: false) {
-            VStack(spacing: 27) {
+            VStack {
                 Button(action: {
                     cameraViewModel.reset()
                     cameraViewModel.type = .newMeal
                     isCameraViewPresented.toggle()
                 }, label: {
                     AddMealView()
-                        .padding([.top], 24)
+                        .padding([.top, .bottom], 24)
                         .padding(.horizontal, .paddingHorizontal)
                 })
                 .tint(.black)
@@ -36,39 +36,36 @@ struct FeedView: View {
                 case true:
                     ForEach(feedMeals.mealList, id: \.id) { eachMeal in
                         if let mealOwner = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
-                            VStack(spacing: 8) {
-                                if let user = loginState.user {
-                                    if let blockedId = user.blockedId {
-                                        if !blockedId.contains(mealOwner.id) {
-                                            FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
-                                                .padding(.horizontal, .paddingHorizontal)
-                                            NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
-                                                .environmentObject(cameraViewModel)
-                                                .environmentObject(loginState)
-                                                .environmentObject(feedMeals)
-                                            ) {
-                                                TabView {
-                                                    ForEach(eachMeal.plates, id: \.self) { plate in
-                                                        PhotoCardView(plate: plate)
-                                                            .padding(.horizontal, .paddingHorizontal)
-                                                    }
-                                                }
-                                            }
-                                            .buttonStyle(PlainButtonStyle())
-                                            .frame(minHeight: 358)
-                                            .tabViewStyle(.page)
-                                            NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
-                                                .environmentObject(cameraViewModel)
-                                                .environmentObject(loginState)
-                                                .environmentObject(feedMeals)
-                                            ) {
-                                                FeedFooterView(meal: eachMeal)
+                            if !loginState.blockedIds.contains(mealOwner.id) {
+                                VStack(spacing: 8) {
+                                    FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
+                                        .padding(.horizontal, .paddingHorizontal)
+                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                        .environmentObject(cameraViewModel)
+                                        .environmentObject(loginState)
+                                        .environmentObject(feedMeals)
+                                    ) {
+                                        TabView {
+                                            ForEach(eachMeal.plates, id: \.self) { plate in
+                                                PhotoCardView(plate: plate)
                                                     .padding(.horizontal, .paddingHorizontal)
-                                                    .environmentObject(feedMeals)
                                             }
-                                            .buttonStyle(PlainButtonStyle())
                                         }
                                     }
+                                    .buttonStyle(PlainButtonStyle())
+                                    .frame(minHeight: 358)
+                                    .tabViewStyle(.page)
+                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                        .environmentObject(cameraViewModel)
+                                        .environmentObject(loginState)
+                                        .environmentObject(feedMeals)
+                                    ) {
+                                        FeedFooterView(meal: eachMeal)
+                                            .padding(.horizontal, .paddingHorizontal)
+                                            .padding(.bottom, 24)
+                                            .environmentObject(feedMeals)
+                                    }
+                                    .buttonStyle(PlainButtonStyle())
                                 }
                             }
                         }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -99,8 +99,6 @@ struct MealDetailView: View {
                                         }
                                     }
                                 }
-                            } else {
-                                Text("Comment Error")
                             }
                         }
                         Rectangle()

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -20,6 +20,7 @@ class LoginStateModel: ObservableObject {
     @Published var isDeleteAccountCompleteAlertRequired = false
     @Published var isShowingDeleteAccountCompleteAlert = false
     @Published var type = types.createAccount
+    @Published var blockedIds: [String] = []
     @Published var blockedUsers: [User] = []
     
     enum types {
@@ -60,6 +61,10 @@ class LoginStateModel: ObservableObject {
                     await MainActor.run {
                         self.user = fetchedUser
                         self.isAppleLoginRequired = false
+                        
+                        if let blockedId = user?.blockedId {
+                            self.blockedIds = blockedId
+                        }
                     }
                 } else {
                     await MainActor.run {
@@ -191,6 +196,7 @@ class LoginStateModel: ObservableObject {
             
             await MainActor.run {
                 self.user = fetchedUser
+                self.blockedIds.removeAll(where: { $0 == blockedUser.id })
             }
             
             if let blockedIds = fetchedUser.blockedId {

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -153,13 +153,14 @@ class LoginStateModel: ObservableObject {
                 let returnedUserData = try await signInToFirebase(credential: credential)
                 let userId = returnedUserData.uid
                 print("애플 로그인 결과: \(userId), \(returnedUserData.email)")
-                try await FirebaseConnector.shared.deleteUserFromAuth()
+                
                 if let imageUrl = user?.profileImageUrl {
                     try await FirebaseConnector.shared.deleteProfileImage(userId: userId)
                 }
                 try await FirebaseConnector.shared.deleteUser(userId: userId)
                 try await FirebaseConnector.shared.deleteCommentsByUser(userId: userId)
                 try await FirebaseConnector.shared.deleteMealsByUser(userId: userId)
+                try await FirebaseConnector.shared.deleteUserFromAuth()
                 await MainActor.run {
                     self.user = nil
                     self.isAppleLoginRequired = false


### PR DESCRIPTION
## 관련 이슈들
- #110 

## 작업 내용
- Firestore - users에 BlockedId 필드가 없으면 Feed가 보이지 않는 문제를 해결했습니다.
- 프로젝트에 맞게 Firestore 보안 규칙을 작성했습니다.
    - 계정 삭제 시 auth만 삭제되고 db에서는 삭제 안되던 문제 해결
    - 규칙 작성 중 프로필뷰 meal history 안보이던 문제 해결

## 리뷰 노트
- 리팩토링 필요한 부분이 많아보이긴 하지만 이번 PR 머지하면 다시 심사 신청해볼 수 있을 것 같습니다!!

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
