### PR TITLE
[Bug] 프로필뷰에서의 Meal 수정사항 뷰에 바로 보이기

### DIFF
--- a/IAteIt/IAteIt/Model/Meal.swift
+++ b/IAteIt/IAteIt/Model/Meal.swift
@@ -26,29 +26,5 @@ extension Meal {
         Meal(id: "meal4", userId: "user2", uploadDate: Date()-60*60*12, plates: [Plate.plates[5]])
     ]
     
-    static let meal1 = Meal(id: "meal1", userId: "user1", location: "New York", caption: "A tasty dinner", uploadDate: Date(timeIntervalSinceNow: -173600), plates: [Plate.plate2], comments: [])
-    
-    static let meal1a = Meal(id: "meal1a", userId: "user1", location: "New York", caption: "A tasty dinner", uploadDate: Date(timeIntervalSinceNow: -293600), plates: [Plate.plate1], comments: [])
-
-    static let meal1b = Meal(id: "meal1b", userId: "user1", location: "New York", caption: "A tasty dinner", uploadDate: Date(timeIntervalSinceNow: -3600), plates: [Plate.plate2, Plate.plate4, Plate.plate5, Plate.plate6], comments: [])
-
-    static let meal1c = Meal(id: "meal1c", userId: "user1", location: "New York", caption: "A tasty dinner", uploadDate: Date(timeIntervalSinceNow: -3600), plates: [Plate.plate1], comments: [])
-
-    static let meal1d = Meal(id: "meal1d", userId: "user1", location: "New York", caption: "A tasty dinner", uploadDate: Date(timeIntervalSinceNow: -3600), plates: [Plate.plate2], comments: [])
-
-    
-    static let meal2 = Meal(id: "meal2", userId: "user1", location: "Paris", caption: "French cuisine", uploadDate: Date(timeIntervalSinceNow: -27200), plates: [Plate.plate2, Plate.plate3], comments: [])
-
-    static let meal2a = Meal(id: "meal2a", userId: "user1", location: "Paris", caption: "French cuisine", uploadDate: Date(timeIntervalSinceNow: -27200), plates: [Plate.plate2, Plate.plate3], comments: [])
-
-    static let meal2b = Meal(id: "meal2b", userId: "user1", location: "Paris", caption: "French cuisine", uploadDate: Date(timeIntervalSinceNow: -507200), plates: [Plate.plate2, Plate.plate3], comments: [])
-
-    static let meal3 = Meal(id: "meal3", userId: "user2", location: "Tokyo", caption: "Sushi time", uploadDate: Date(timeIntervalSinceNow: -2500800), plates: [Plate.plate4, Plate.plate5, Plate.plate6], comments: [])
-    
-    static let meal4 = Meal(id: "meal3", userId: "user2", location: "Tokyo", caption: "Sushi time", uploadDate: Date(timeIntervalSinceNow: -2500800), plates: [Plate.plate7, Plate.plate8, Plate.plate9, Plate.plate10, Plate.plate11, Plate.plate12], comments: [])
-    
-    static let meal5 = Meal(id: "meal3", userId: "user2", location: "Tokyo", caption: "Sushi time", uploadDate: Date(), plates: [Plate.plate7, Plate.plate8, Plate.plate9, Plate.plate10, Plate.plate11, Plate.plate12], comments: [])
-
-    
-    static let mealsByUser = [meal1, meal1a, meal1b, meal1c, meal1d, meal2, meal2a, meal2b, meal3, meal4, meal5]
+    static let meal1 = Meal(userId: "user1", uploadDate: Date(), plates: [], comments: [])
 }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -36,46 +36,44 @@ struct FeedView: View {
                 case true:
                     ForEach(feedMeals.mealList) { eachMeal in
                         if let mealOwner = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
-                            if !loginState.blockedIds.contains(mealOwner.id) {
-                                VStack(spacing: 8) {
-                                    FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
-                                        .padding(.horizontal, .paddingHorizontal)
-                                    NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
-                                        .environmentObject(cameraViewModel)
-                                        .environmentObject(loginState)
-                                        .environmentObject(feedMeals)
-                                    ) {
-                                        TabView {
-                                            ForEach(eachMeal.plates) { plate in
-                                                PhotoCardView(plate: plate)
-                                                    .pinchZoom()
-                                                    .padding(.horizontal, .paddingHorizontal)
-                                            }
+                            VStack(spacing: 8) {
+                                FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
+                                    .padding(.horizontal, .paddingHorizontal)
+                                NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
+                                    TabView {
+                                        ForEach(eachMeal.plates) { plate in
+                                            PhotoCardView(plate: plate)
+                                                .pinchZoom()
+                                                .padding(.horizontal, .paddingHorizontal)
                                         }
                                     }
-                                    .buttonStyle(PlainButtonStyle())
-                                    .frame(minHeight: 358)
-                                    .tabViewStyle(.page)
-                                    .simultaneousGesture(TapGesture().onEnded{
-                                        feedMeals.currentMeal = eachMeal
-                                    })
-                                    NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
-                                        .environmentObject(cameraViewModel)
-                                        .environmentObject(loginState)
-                                        .environmentObject(feedMeals)
-                                    ) {
-                                        FeedFooterView(meal: eachMeal)
-                                            .padding(.horizontal, .paddingHorizontal)
-                                            .padding(.bottom, 24)
-                                            .environmentObject(feedMeals)
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
-                                    .simultaneousGesture(TapGesture().onEnded{
-                                        feedMeals.currentMeal = eachMeal
-                                    })
                                 }
                                 .buttonStyle(PlainButtonStyle())
+                                .frame(minHeight: 358)
+                                .tabViewStyle(.page)
+                                .simultaneousGesture(TapGesture().onEnded{
+                                    feedMeals.currentMeal = eachMeal
+                                })
+                                NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
+                                    FeedFooterView(meal: eachMeal)
+                                        .padding(.horizontal, .paddingHorizontal)
+                                        .padding(.bottom, 24)
+                                        .environmentObject(feedMeals)
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .simultaneousGesture(TapGesture().onEnded{
+                                    feedMeals.currentMeal = eachMeal
+                                })
                             }
+                            .buttonStyle(PlainButtonStyle())
                         }
                     }
                 default:

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -40,7 +40,7 @@ struct FeedView: View {
                                 VStack(spacing: 8) {
                                     FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
                                         .padding(.horizontal, .paddingHorizontal)
-                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                    NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
                                         .environmentObject(cameraViewModel)
                                         .environmentObject(loginState)
                                         .environmentObject(feedMeals)
@@ -55,7 +55,10 @@ struct FeedView: View {
                                     .buttonStyle(PlainButtonStyle())
                                     .frame(minHeight: 358)
                                     .tabViewStyle(.page)
-                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                    .simultaneousGesture(TapGesture().onEnded{
+                                        feedMeals.currentMeal = eachMeal
+                                    })
+                                    NavigationLink(destination: MealDetailView(user: mealOwner, commentList: feedMeals.commentList)
                                         .environmentObject(cameraViewModel)
                                         .environmentObject(loginState)
                                         .environmentObject(feedMeals)
@@ -66,6 +69,9 @@ struct FeedView: View {
                                             .environmentObject(feedMeals)
                                     }
                                     .buttonStyle(PlainButtonStyle())
+                                    .simultaneousGesture(TapGesture().onEnded{
+                                        feedMeals.currentMeal = eachMeal
+                                    })
                                 }
                             }
                         }

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -27,6 +27,8 @@ final class FeedMealModel: ObservableObject {
     @Published var myMealHistoryCommentList: [String: [Comment]] = [:]
     @Published var myMealHistorySorted: [(key: String, value: [Meal])] = []
 
+    @Published var currentMeal: Meal?
+    
     init() {
         self.refreshMealsAndUsers()
     }
@@ -71,16 +73,15 @@ final class FeedMealModel: ObservableObject {
     func saveCaption(meal: Meal, content: String) {
         Task {
             await FirebaseConnector.shared.setMealCaption(meal: meal, caption: content)
-            mealList.indices.forEach { index in
-                if mealList[index].id == meal.id {
-                    DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                self.currentMeal?.caption = content
+                self.mealList.indices.forEach { index in
+                    if self.mealList[index].id == meal.id {
                         self.mealList[index].caption = content
                     }
                 }
-            }
-            myMealHistory.indices.forEach { index in
-                if myMealHistory[index].id == meal.id {
-                    DispatchQueue.main.async {
+                self.myMealHistory.indices.forEach { index in
+                    if self.myMealHistory[index].id == meal.id {
                         self.myMealHistory[index].caption = content
                     }
                 }
@@ -91,16 +92,15 @@ final class FeedMealModel: ObservableObject {
     func saveLocation(meal: Meal, content: String) {
         Task {
             await FirebaseConnector.shared.setMealLocation(meal: meal, location: content)
-            mealList.indices.forEach { index in
-                if mealList[index].id == meal.id {
-                    DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                self.currentMeal?.location = content
+                self.mealList.indices.forEach { index in
+                    if self.mealList[index].id == meal.id {
                         self.mealList[index].location = content
                     }
                 }
-            }
-            myMealHistory.indices.forEach { index in
-                if myMealHistory[index].id == meal.id {
-                    DispatchQueue.main.async {
+                self.myMealHistory.indices.forEach { index in
+                    if self.myMealHistory[index].id == meal.id {
                         self.myMealHistory[index].location = content
                     }
                 }
@@ -114,6 +114,7 @@ final class FeedMealModel: ObservableObject {
             try await FirebaseConnector.shared.deletePlate(meal: meal, plate: plate)
             try await FirebaseConnector.shared.deletePlateImage(plateId: plate.id)
             DispatchQueue.main.async {
+                self.currentMeal?.plates.removeAll(where: { $0.id == plate.id })
                 if let index = self.mealList.firstIndex(where: { $0.id == mealId }) {
                     self.mealList[index].plates.removeAll(where: { $0.id == plate.id })
                 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -22,145 +22,146 @@ struct MealDetailView: View {
     @State private var isReportPresented = false
     @State private var isBlockingAlertPresented = false
     
-    var meal: Meal
+//    var meal: Meal
     var user: User
     var commentList: [String: [Comment]]
     
     var body: some View {
-        ZStack {
-            ScrollView {
-                VStack {
-                    MealDetailTopView(commentBar: commentBar, isMyMeal: $isMyMeal, isTodayMeal: $isTodayMeal, meal: meal)
-                        .padding(.horizontal, .paddingHorizontal)
-                    
-                    TabView {
-                        ForEach(meal.plates, id: \.id) { plate in
-                            PhotoCardView(plate: plate)
-                                .padding(.horizontal, .paddingHorizontal)
-                                .contextMenu {
-                                    if isMyMeal && (meal.plates.count > 1) {
-                                        Button(role: .destructive, action: {
-                                            isShowingPlateDeleteAlert = true
-                                            print(plate)
-                                        }, label: {
-                                            Label("Delete this plate", systemImage: "trash")
-                                        })
+        if let currentMeal = feedMeals.currentMeal {
+            ZStack {
+                ScrollView {
+                    VStack {
+                        MealDetailTopView(commentBar: commentBar, isMyMeal: $isMyMeal, isTodayMeal: $isTodayMeal, meal: currentMeal)
+                            .padding(.horizontal, .paddingHorizontal)
+                        
+                        TabView {
+                            ForEach(currentMeal.plates, id: \.id) { plate in
+                                PhotoCardView(plate: plate)
+                                    .padding(.horizontal, .paddingHorizontal)
+                                    .contextMenu {
+                                        if isMyMeal && (currentMeal.plates.count > 1) {
+                                            Button(role: .destructive, action: {
+                                                isShowingPlateDeleteAlert = true
+                                                print(plate)
+                                            }, label: {
+                                                Label("Delete this plate", systemImage: "trash")
+                                            })
+                                        }
                                     }
-                                }
-                                .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
-                                    Button("Delete", role: .destructive, action: {
-                                        feedMeals.deletePlate(meal: meal, plate: plate)
+                                    .alert("Delete this plate", isPresented: $isShowingPlateDeleteAlert, actions: {
+                                        Button("Delete", role: .destructive, action: {
+                                            feedMeals.deletePlate(meal: currentMeal, plate: plate)
+                                        })
+                                        Button("Cancel", role: .cancel, action: {})
+                                    }, message: {
+                                        Text("This action is irreversible.")
                                     })
-                                    Button("Cancel", role: .cancel, action: {})
-                                }, message: {
-                                    Text("This action is irreversible.")
-                                })
+                            }
                         }
-                    }
-                    .frame(minHeight: 358)
-                    .tabViewStyle(.page)
-                    
-                    if isMyMeal && isTodayMeal {
-                        HStack {
-                            Spacer()
-                            Button(action: {
-                                cameraViewModel.reset()
-                                cameraViewModel.type = .addPlate
-                                isCameraViewPresented.toggle()
-                            }, label: {
-                                AddPlateButtonView()
+                        .frame(minHeight: 358)
+                        .tabViewStyle(.page)
+                        
+                        if isMyMeal && isTodayMeal {
+                            HStack {
+                                Spacer()
+                                Button(action: {
+                                    cameraViewModel.reset()
+                                    cameraViewModel.type = .addPlate
+                                    isCameraViewPresented.toggle()
+                                }, label: {
+                                    AddPlateButtonView()
+                                })
+                            }
+                            .padding(.horizontal, .paddingHorizontal)
+                            .fullScreenCover(isPresented: $isCameraViewPresented, content: {
+                                CameraView(viewModel: cameraViewModel, mealAddPlateTo: currentMeal)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
                             })
                         }
-                        .padding(.horizontal, .paddingHorizontal)
-                        .fullScreenCover(isPresented: $isCameraViewPresented, content: {
-                            CameraView(viewModel: cameraViewModel, mealAddPlateTo: meal)
-                                .environmentObject(loginState)
-                                .environmentObject(feedMeals)
-                        })
-                    }
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(commentList[meal.id!] ?? [], id:\.self) { comment in
-                            if let user = feedMeals.allUsers.first(where: { $0.id == comment.userId }) {
-                                let isMyComment = loginState.user?.id == comment.userId
-                                ZStack {
-                                    CommentView(user: user, comment: comment)
-                                    HStack {
-                                        Spacer()
-                                        if isMyComment {
-                                            Menu(content: {
-                                                Button(role: .destructive, action: {
-                                                    feedMeals.deleteComment(meal: meal, comment: comment)
+                        VStack(alignment: .leading, spacing: 12) {
+                            ForEach(commentList[currentMeal.id!] ?? [], id:\.self) { comment in
+                                if let user = feedMeals.allUsers.first(where: { $0.id == comment.userId }) {
+                                    let isMyComment = loginState.user?.id == comment.userId
+                                    ZStack {
+                                        CommentView(user: user, comment: comment)
+                                        HStack {
+                                            Spacer()
+                                            if isMyComment {
+                                                Menu(content: {
+                                                    Button(role: .destructive, action: {
+                                                        feedMeals.deleteComment(meal: currentMeal, comment: comment)
+                                                    }, label: {
+                                                        Label("Delete this comment", systemImage: "trash")
+                                                    })
                                                 }, label: {
-                                                    Label("Delete this comment", systemImage: "trash")
+                                                    Image(systemName: "ellipsis")
                                                 })
-                                            }, label: {
-                                                Image(systemName: "ellipsis")
-                                            })
+                                            }
                                         }
                                     }
                                 }
                             }
+                            Rectangle()
+                                .fill(Color.white.opacity(0))
+                                .frame(height: 80)
                         }
-                        Rectangle()
-                            .fill(Color.white.opacity(0))
-                            .frame(height: 80)
-                    }
-                    .padding([.top], 24)
-                    .padding(.horizontal, .paddingHorizontal)
-
-                }
-            }
-            .onTapGesture {
-                self.hideKeyboard()
-            }
-            if isTodayMeal {
-                ZStack {
-                    VStack {
-                        Spacer()
-                        Rectangle()
-                            .fill(
-                                LinearGradient(gradient: Gradient(colors: [Color.white, Color.white.opacity(0)]),
-                                               startPoint: UnitPoint(x: 0.5, y: 1-100/200),
-                                               endPoint: .top)
-                            )
-                            .ignoresSafeArea()
-                            .frame(height: 115)
+                        .padding([.top], 24)
+                        .padding(.horizontal, .paddingHorizontal)
+                        
                     }
                 }
-                AddCommentBarView(feedMeals: feedMeals, commentBar: commentBar, meal: meal)
-                    .padding([.bottom], 10)
-                    .padding(.horizontal, .paddingHorizontal)
+                .onTapGesture {
+                    self.hideKeyboard()
+                }
+                if isTodayMeal {
+                    ZStack {
+                        VStack {
+                            Spacer()
+                            Rectangle()
+                                .fill(
+                                    LinearGradient(gradient: Gradient(colors: [Color.white, Color.white.opacity(0)]),
+                                                   startPoint: UnitPoint(x: 0.5, y: 1-100/200),
+                                                   endPoint: .top)
+                                )
+                                .ignoresSafeArea()
+                                .frame(height: 115)
+                        }
+                    }
+                    AddCommentBarView(feedMeals: feedMeals, commentBar: commentBar, meal: currentMeal)
+                        .padding([.bottom], 10)
+                        .padding(.horizontal, .paddingHorizontal)
+                }
             }
-        }
-        .navigationTitle(navTitleText)
-        .navigationBarTitleDisplayMode(.inline)
-        .alert("Delete this meal", isPresented: $isShowingMealDeleteAlert, actions: {
-            Button("Delete", role: .destructive, action: {
-                feedMeals.deleteMeal(meal: meal)
+            .navigationTitle(navTitleText)
+            .navigationBarTitleDisplayMode(.inline)
+            .alert("Delete this meal", isPresented: $isShowingMealDeleteAlert, actions: {
+                Button("Delete", role: .destructive, action: {
+                    feedMeals.deleteMeal(meal: currentMeal)
+                })
+                Button("Cancel", role: .cancel, action: {})
+            }, message: {
+                Text("This action is irreversible.")
             })
-            Button("Cancel", role: .cancel, action: {})
-        }, message: {
-            Text("This action is irreversible.")
-        })
-        .alert("Blocking this user", isPresented: $isBlockingAlertPresented, actions: {
-            Button("Block", role: .destructive, action: {
-                if let blocker = loginState.user {
-                    Task{
-                        try await FirebaseConnector().addBlockedId(user: blocker, BlockedId: meal.userId)
-                        loginState.checkLoginUser()
+            .alert("Blocking this user", isPresented: $isBlockingAlertPresented, actions: {
+                Button("Block", role: .destructive, action: {
+                    if let blocker = loginState.user {
+                        Task{
+                            try await FirebaseConnector().addBlockedId(user: blocker, BlockedId: currentMeal.userId)
+                            loginState.checkLoginUser()
+                        }
                     }
-                }
+                })
+                Button("Cancel", role: .cancel, action: {})
+            }, message: {
+                Text("Blocked users won't be able to see your posts, and their posts won't appear on your feed..")
             })
-            Button("Cancel", role: .cancel, action: {})
-        }, message: {
-            Text("Blocked users won't be able to see your posts, and their posts won't appear on your feed..")
-        })
-        .sheet(isPresented: $isReportPresented) {
-            ReportView(meal: meal, user: user, isReportPresented: $isReportPresented)
+            .sheet(isPresented: $isReportPresented) {
+                ReportView(meal: currentMeal, user: user, isReportPresented: $isReportPresented)
                     .environmentObject(loginState)
-                }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
                     Menu(content: {
                         if isMyMeal {
                             Button(role: .destructive, action: {
@@ -169,25 +170,26 @@ struct MealDetailView: View {
                                 Label("Delete this meal", systemImage: "trash")
                             })
                         } else {
-                                Button(role: .destructive, action: {
-                                    isReportPresented = true
-                                }, label: {
-                                    Label("Report this meal", systemImage: "exclamationmark.triangle")
-                                })
-                                Button(role: .destructive, action: {
-                                    isBlockingAlertPresented = true
-                                }, label: {
-                                    Label("Block this user", systemImage: "nosign")
-                                })
+                            Button(role: .destructive, action: {
+                                isReportPresented = true
+                            }, label: {
+                                Label("Report this meal", systemImage: "exclamationmark.triangle")
+                            })
+                            Button(role: .destructive, action: {
+                                isBlockingAlertPresented = true
+                            }, label: {
+                                Label("Block this user", systemImage: "nosign")
+                            })
                         }
                     }, label: {
                         Image(systemName: "ellipsis")
                     })
+                }
             }
-        }
-        .onAppear {
-            configMyMealUI()
-            configTodayMealUI()
+            .onAppear {
+                configMyMealUI()
+                configTodayMealUI()
+            }
         }
     }
 }
@@ -199,7 +201,8 @@ extension MealDetailView {
     }
     
     func configTodayMealUI() {
-        let timeDiff = Int(Date().timeIntervalSince(meal.uploadDate))
+        guard let currentMeal = feedMeals.currentMeal else { return }
+        let timeDiff = Int(Date().timeIntervalSince(currentMeal.uploadDate))
         isTodayMeal = timeDiff < 86400 ? true : false
     }
 }
@@ -207,6 +210,6 @@ extension MealDetailView {
 
 struct MealDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        MealDetailView(commentBar: CommentBar(), meal: Meal.meals[2], user: User.users[0], commentList: [:])
+        MealDetailView(commentBar: CommentBar(), user: User.users[0], commentList: [:])
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -190,6 +190,9 @@ struct MealDetailView: View {
                 configMyMealUI()
                 configTodayMealUI()
             }
+            .onDisappear {
+                feedMeals.currentMeal = nil
+            }
         }
     }
 }

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -98,7 +98,7 @@ struct MealDetailView: View {
                                                 }, label: {
                                                     Image(systemName: "ellipsis")
                                                         .frame(width: .buttonHitRegion, height: .buttonHitRegion)
-                                            }
+                                                })
                                             }
                                         }
                                     }

--- a/IAteIt/IAteIt/View/MyProfile/Component/MealListView.swift
+++ b/IAteIt/IAteIt/View/MyProfile/Component/MealListView.swift
@@ -41,7 +41,7 @@ struct MealListView: View {
             
             ZStack {
                 NavigationLink(
-                    destination: MealDetailView(meal: selectedMeal, user: user, commentList: feedMeals.myMealHistoryCommentList)
+                    destination: MealDetailView(user: user, commentList: feedMeals.myMealHistoryCommentList)
                         .environmentObject(cameraViewModel)
                         .environmentObject(loginState)
                         .environmentObject(feedMeals),
@@ -56,7 +56,7 @@ struct MealListView: View {
                         HStack(alignment: .center, spacing: 6) {
                             ForEach(meals, id: \.uploadDate) { meal in
                                 NavigationLink {
-                                    MealDetailView(meal: meal, user: user, commentList: feedMeals.myMealHistoryCommentList)
+                                    MealDetailView(user: user, commentList: feedMeals.myMealHistoryCommentList)
                                         .environmentObject(cameraViewModel)
                                         .environmentObject(loginState)
                                         .environmentObject(feedMeals)
@@ -78,6 +78,10 @@ struct MealListView: View {
                                         }
                                     }
                                 }
+                                .simultaneousGesture(TapGesture().onEnded{
+                                    feedMeals.currentMeal = meal
+                                    print("Hello world!")
+                                })
                             }
                         }
                         .padding(.horizontal, .paddingHorizontal)
@@ -95,6 +99,7 @@ struct MealListView: View {
                                     .frame(height: 128)
                                     .cornerRadius(15)
                                     .onTapGesture {
+                                        feedMeals.currentMeal = meal
                                         selectedMeal = meal
                                         isActive = true
                                     }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -180,6 +180,7 @@ extension CameraView {
             let plateImageUrl = try await FirebaseConnector.shared.uploadPlateImage(plateId: plate.id, image: image)
             plate.imageUrl = plateImageUrl
             DispatchQueue.main.async {
+                feedMeals.currentMeal?.plates.append(plate)
                 if let index = feedMeals.mealList.firstIndex(where: {$0.id == meal.id}) {
                     feedMeals.mealList[index].plates.append(plate)
                 }

--- a/IAteIt/IAteIt/View/Upload/CameraView.swift
+++ b/IAteIt/IAteIt/View/Upload/CameraView.swift
@@ -183,6 +183,9 @@ extension CameraView {
                 if let index = feedMeals.mealList.firstIndex(where: {$0.id == meal.id}) {
                     feedMeals.mealList[index].plates.append(plate)
                 }
+                if let index = feedMeals.myMealHistory.firstIndex(where: { $0.id == meal.id }) {
+                    feedMeals.myMealHistory[index].plates.append(plate)
+                }
             }
             try await FirebaseConnector.shared.addPlateToMeal(meal: meal, plate: plate)
         }


### PR DESCRIPTION
## 관련 이슈들
- #113 

## 작업 내용
- meal 수정 시 FeedMealModel의 myMealHistory에서도 변경되도록 했습니다.
- MealDetailView를 FeedMealModel의 `@Published var currentMeal: Meal?`로 그리도록 변경하고, 수정사항은 currentMeal에도 반영되도록 했습니다.
- currentMeal로만 상세뷰가 그려지므로 예기치않게 meal1이 표시될 일도 없을 듯 하지만, meal1의 "tasty dinner, New York"등의 텍스트는 삭제했습니다.

## 리뷰 노트
- FeedMealModel에 FeedView를 위한 `mealList`, ProfileView를 위한 `myMealHistory`, MealDetailView를 위한 `currentMeal`(이번에 추가)이 있는 상황입니다.
- 프로필뷰에서의 meal 수정 시 `myMealHistory`도 업데이트해주는것만으로는 상세뷰에서 바로 변경되지 않아서 `currentMeal`을 추가했습니다.
- 그에 따라 meal 수정(캡션, 장소, plate 등) 시 `mealList`, `myMealHistory`, `currentMeal`을 모두 수정해주고 있는데.. 이게 뭔가 눈속임같기도 하고 해서 찜찜한데 다른 아이디어가 떠오르지 않아 올립니다...

## 스크린샷(UX의 경우 gif)
https://github.com/Bnomad-space/IAteIt/assets/103012157/cb1b7324-80dd-4d7d-bcbd-10cdaeacd9fb

## Reference
- [NavigationLink to perform an action](https://stackoverflow.com/questions/57666620/is-it-possible-for-a-navigationlink-to-perform-an-action-in-addition-to-navigati)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
