### PR TITLE
[bug] 자신의 코멘트 오른쪽 버튼 탭 어려움 해결

### DIFF
--- a/IAteIt/IAteIt/Utility/Constants.swift
+++ b/IAteIt/IAteIt/Utility/Constants.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 extension CGFloat {
-    public static let paddingHorizontal: CGFloat = 16
+    static let paddingHorizontal: CGFloat = 16
+    static let buttonHitRegion: CGFloat = 44
+    static let commentBottomArea: CGFloat = 80
 }
 
 enum Const {

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -125,7 +125,7 @@ struct MealDetailView: View {
                                                endPoint: .top)
                             )
                             .ignoresSafeArea()
-                            .frame(height: .commentBottomArea)
+                            .frame(height: .commentBottomArea + 16)
                     }
                 }
                 AddCommentBarView(feedMeals: feedMeals, commentBar: commentBar, meal: meal)

--- a/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
+++ b/IAteIt/IAteIt/View/MealDetail/MealDetailView.swift
@@ -95,6 +95,7 @@ struct MealDetailView: View {
                                                 })
                                             }, label: {
                                                 Image(systemName: "ellipsis")
+                                                    .frame(width: .buttonHitRegion, height: .buttonHitRegion)
                                             })
                                         }
                                     }
@@ -103,7 +104,7 @@ struct MealDetailView: View {
                         }
                         Rectangle()
                             .fill(Color.white.opacity(0))
-                            .frame(height: 80)
+                            .frame(height: .commentBottomArea)
                     }
                     .padding([.top], 24)
                     .padding(.horizontal, .paddingHorizontal)
@@ -124,7 +125,7 @@ struct MealDetailView: View {
                                                endPoint: .top)
                             )
                             .ignoresSafeArea()
-                            .frame(height: 115)
+                            .frame(height: .commentBottomArea)
                     }
                 }
                 AddCommentBarView(feedMeals: feedMeals, commentBar: commentBar, meal: meal)


### PR DESCRIPTION
## 관련 이슈들
- #116 

## 작업 내용
- 자신의 코멘트 오른쪽의 ellipsis 모양 버튼의 터치 영역을 44pt x 44pt로 키웠습니다. (사이즈는 HIG 참고)
- 코멘트바 뒤쪽의 gradient 영역의 높이를 코멘트 하단 빈 공간 영역과 동일하게 맞췄습니다.
    - [수정] gradient 영역이 좀 안보여서 높이를 16만큼만 더 키웠습니다.

## 리뷰 노트
- 수정한 코드가 적어서 뭔가 민망하네요..

## Reference
- [Human Interface Guidelines - Buttons](https://developer.apple.com/design/human-interface-guidelines/buttons)

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
