### PR TITLE
[fix] 차단당한 유저가 차단한 유저의 게시물을 볼 수 없도록 함

### DIFF
--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -36,37 +36,35 @@ struct FeedView: View {
                 case true:
                     ForEach(feedMeals.mealList, id: \.id) { eachMeal in
                         if let mealOwner = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
-                            if !loginState.blockedIds.contains(mealOwner.id) {
-                                VStack(spacing: 8) {
-                                    FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
-                                        .padding(.horizontal, .paddingHorizontal)
-                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
-                                        .environmentObject(cameraViewModel)
-                                        .environmentObject(loginState)
-                                        .environmentObject(feedMeals)
-                                    ) {
-                                        TabView {
-                                            ForEach(eachMeal.plates, id: \.self) { plate in
-                                                PhotoCardView(plate: plate)
-                                                    .padding(.horizontal, .paddingHorizontal)
-                                            }
+                            VStack(spacing: 8) {
+                                FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
+                                    .padding(.horizontal, .paddingHorizontal)
+                                NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
+                                    TabView {
+                                        ForEach(eachMeal.plates, id: \.self) { plate in
+                                            PhotoCardView(plate: plate)
+                                                .padding(.horizontal, .paddingHorizontal)
                                         }
                                     }
-                                    .buttonStyle(PlainButtonStyle())
-                                    .frame(minHeight: 358)
-                                    .tabViewStyle(.page)
-                                    NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
-                                        .environmentObject(cameraViewModel)
-                                        .environmentObject(loginState)
-                                        .environmentObject(feedMeals)
-                                    ) {
-                                        FeedFooterView(meal: eachMeal)
-                                            .padding(.horizontal, .paddingHorizontal)
-                                            .padding(.bottom, 24)
-                                            .environmentObject(feedMeals)
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
                                 }
+                                .buttonStyle(PlainButtonStyle())
+                                .frame(minHeight: 358)
+                                .tabViewStyle(.page)
+                                NavigationLink(destination: MealDetailView(meal: eachMeal, user: mealOwner, commentList: feedMeals.commentList)
+                                    .environmentObject(cameraViewModel)
+                                    .environmentObject(loginState)
+                                    .environmentObject(feedMeals)
+                                ) {
+                                    FeedFooterView(meal: eachMeal)
+                                        .padding(.horizontal, .paddingHorizontal)
+                                        .padding(.bottom, 24)
+                                        .environmentObject(feedMeals)
+                                }
+                                .buttonStyle(PlainButtonStyle())
                             }
                         }
                     }

--- a/IAteIt/IAteIt/View/Feed/FeedView.swift
+++ b/IAteIt/IAteIt/View/Feed/FeedView.swift
@@ -34,7 +34,7 @@ struct FeedView: View {
                 })
                 switch feedMeals.mealList.count != 0 {
                 case true:
-                    ForEach(feedMeals.mealList, id: \.id) { eachMeal in
+                    ForEach(feedMeals.mealList) { eachMeal in
                         if let mealOwner = feedMeals.allUsers.first(where: { $0.id == eachMeal.userId }) {
                             VStack(spacing: 8) {
                                 FeedHeaderView(feedMeals: feedMeals, meal: eachMeal, user: mealOwner)
@@ -45,7 +45,7 @@ struct FeedView: View {
                                     .environmentObject(feedMeals)
                                 ) {
                                     TabView {
-                                        ForEach(eachMeal.plates, id: \.self) { plate in
+                                        ForEach(eachMeal.plates) { plate in
                                             PhotoCardView(plate: plate)
                                                 .pinchZoom()
                                                 .padding(.horizontal, .paddingHorizontal)

--- a/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
+++ b/IAteIt/IAteIt/View/Feed/Model/FeedMealModel.swift
@@ -9,11 +9,7 @@ import SwiftUI
 import FirebaseAuth
 
 final class FeedMealModel: ObservableObject {
-    @Published var mealList: [Meal] = [] {
-        didSet {
-            self.mealList.sorted { $0.uploadDate > $1.uploadDate }
-        }
-    }
+    @Published var mealList: [Meal] = []
     @Published var allUsers: [User] = []
     @Published var commentList: [String: [Comment]] = [:]
     
@@ -46,8 +42,10 @@ final class FeedMealModel: ObservableObject {
             self.mealList = fetchedMealList
             
             for meal in self.mealList {
-                FirebaseConnector.shared.fetchMealComments(mealId: meal.id!) { comments in
-                    self.commentList[meal.id!] = comments
+                FirebaseConnector.shared.fetchMealComments(mealId: meal.id!) { [weak self] comments in
+                    DispatchQueue.main.async {
+                        self?.commentList[meal.id!] = comments
+                    }
                 }
             }
         }
@@ -58,8 +56,10 @@ final class FeedMealModel: ObservableObject {
         Task {
             self.myMealHistory = try await FirebaseConnector.shared.fetchUserMealHistory(userId: user.id)
             for meal in self.myMealHistory {
-                FirebaseConnector.shared.fetchMealComments(mealId: meal.id!) { comments in
-                    self.myMealHistoryCommentList[meal.id!] = comments
+                FirebaseConnector.shared.fetchMealComments(mealId: meal.id!) { [weak self] comments in
+                    DispatchQueue.main.async {
+                        self?.myMealHistoryCommentList[meal.id!] = comments
+                    }
                 }
             }
             myMealHistorySorted = Dictionary(grouping: myMealHistory) { $0.uploadDate.toDateString() }

--- a/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
+++ b/IAteIt/IAteIt/View/SignUp/Model/LoginStateModel.swift
@@ -20,7 +20,6 @@ class LoginStateModel: ObservableObject {
     @Published var isDeleteAccountCompleteAlertRequired = false
     @Published var isShowingDeleteAccountCompleteAlert = false
     @Published var type = types.createAccount
-    @Published var blockedIds: [String] = []
     @Published var blockedUsers: [User] = []
     
     enum types {
@@ -61,10 +60,6 @@ class LoginStateModel: ObservableObject {
                     await MainActor.run {
                         self.user = fetchedUser
                         self.isAppleLoginRequired = false
-                        
-                        if let blockedId = user?.blockedId {
-                            self.blockedIds = blockedId
-                        }
                     }
                 } else {
                     await MainActor.run {
@@ -197,7 +192,6 @@ class LoginStateModel: ObservableObject {
             
             await MainActor.run {
                 self.user = fetchedUser
-                self.blockedIds.removeAll(where: { $0 == blockedUser.id })
             }
             
             if let blockedIds = fetchedUser.blockedId {


### PR DESCRIPTION
## 관련 이슈들
- #118 

## 작업 내용
- FeedMealModel의 `getMealListIn24Hours()`에서 `mealList`를 세팅할 때 내가 차단한 유저, 나를 차단한 유저의 게시물이 포함되지 않도록 했습니다.

## 리뷰 노트
- #104 에서 차단한 유저의 게시물을 view에서 제외해주자는 이야기가 있었던 것 같아서.. 이 방법에 대한 의견이 궁금합니다ㅜㅜ

## 체크리스트
- [x] 올바른 브랜치로 PR을 날리고 있는지 더블CHECK!
- [x] 확인을 위해 바꾼 SceneDelegate.swift를 원래의 상태로 바꾸어 놓으셨나요?
- [x] 불필요한 주석과 프린트문은 삭제가 되었나요?
