### PR TITLE
[feat] request, response 프로토콜 추가

### DIFF
--- a/IAteIt/IAteIt.xcodeproj/project.pbxproj
+++ b/IAteIt/IAteIt.xcodeproj/project.pbxproj
@@ -74,6 +74,10 @@
 		DF2213A029BB293C000134FC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = DF22139F29BB293C000134FC /* FirebaseStorage */; };
 		DF2213A229BB2ADC000134FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A129BB2ADC000134FC /* AppDelegate.swift */; };
 		DF2213A529BB324F000134FC /* FirebaseConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2213A429BB324F000134FC /* FirebaseConnector.swift */; };
+		DF443F1A2B64FA80009D6B30 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF443F192B64FA80009D6B30 /* Request.swift */; };
+		DF443F1C2B64FA85009D6B30 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF443F1B2B64FA85009D6B30 /* Response.swift */; };
+		DF443F1E2B66AA92009D6B30 /* HttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF443F1D2B66AA92009D6B30 /* HttpMethod.swift */; };
+		DF443F202B66AB49009D6B30 /* JwtRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF443F1F2B66AB49009D6B30 /* JwtRequired.swift */; };
 		DF883D4229B58F2C0029DC60 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4129B58F2C0029DC60 /* User.swift */; };
 		DF883D4629B58F3D0029DC60 /* Plate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4529B58F3D0029DC60 /* Plate.swift */; };
 		DF883D4829B58F430029DC60 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF883D4729B58F430029DC60 /* Comment.swift */; };
@@ -145,6 +149,10 @@
 		DF22139A29BB2843000134FC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		DF2213A129BB2ADC000134FC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DF2213A429BB324F000134FC /* FirebaseConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseConnector.swift; sourceTree = "<group>"; };
+		DF443F192B64FA80009D6B30 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		DF443F1B2B64FA85009D6B30 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		DF443F1D2B66AA92009D6B30 /* HttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpMethod.swift; sourceTree = "<group>"; };
+		DF443F1F2B66AB49009D6B30 /* JwtRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JwtRequired.swift; sourceTree = "<group>"; };
 		DF883D4129B58F2C0029DC60 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DF883D4529B58F3D0029DC60 /* Plate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plate.swift; sourceTree = "<group>"; };
 		DF883D4729B58F430029DC60 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
@@ -433,12 +441,24 @@
 		DF2213A329BB3215000134FC /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				DF443F182B64FA66009D6B30 /* Utils */,
 				DF2213A429BB324F000134FC /* FirebaseConnector.swift */,
 				7E48DC1B29F42F3E0079E896 /* FirebaseConnector+ExtensionForMeals.swift */,
 				7E48DC1D29F42FFE0079E896 /* FirebaseConnector+ExtensionForComments.swift */,
 				040EB7322A55660D00E20A4D /* FirebaseConnector+ExtensionForReports.swift */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		DF443F182B64FA66009D6B30 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				DF443F192B64FA80009D6B30 /* Request.swift */,
+				DF443F1B2B64FA85009D6B30 /* Response.swift */,
+				DF443F1D2B66AA92009D6B30 /* HttpMethod.swift */,
+				DF443F1F2B66AB49009D6B30 /* JwtRequired.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -544,6 +564,8 @@
 				DF883D4829B58F430029DC60 /* Comment.swift in Sources */,
 				7E6069D529A5CAFA00284CBD /* MyProfileView.swift in Sources */,
 				045339E72A0CAE59007F74F0 /* EmptyMealView.swift in Sources */,
+				DF443F1E2B66AA92009D6B30 /* HttpMethod.swift in Sources */,
+				DF443F1C2B64FA85009D6B30 /* Response.swift in Sources */,
 				8C73F00329BDD010007D1A1E /* MealListView.swift in Sources */,
 				7E2E84EA2AA77B960056D007 /* WebView.swift in Sources */,
 				7E9FEF3229DE9BFA002E7211 /* TextField+Extension.swift in Sources */,
@@ -578,9 +600,11 @@
 				7E42C95729DC112B00ABE32D /* MealDetailTopView.swift in Sources */,
 				04E9931929B9E0CB00BE3F91 /* ProfilePhotoButtonView.swift in Sources */,
 				7E229BD32A5DCA45009020BB /* PlateImageErrorView.swift in Sources */,
+				DF443F1A2B64FA80009D6B30 /* Request.swift in Sources */,
 				7E407CCC2A044D1B001CAFBF /* FeedMealModel.swift in Sources */,
 				7EDF91A929E97CD800FB23A8 /* CommentBar.swift in Sources */,
 				7E229BD12A5DC414009020BB /* InnerShadowModifier.swift in Sources */,
+				DF443F202B66AB49009D6B30 /* JwtRequired.swift in Sources */,
 				7E407CCE2A04F682001CAFBF /* AuthDataResultModel.swift in Sources */,
 				0487509B29B83DBD006836D1 /* FeedFooterView.swift in Sources */,
 				7E6069E029A7A7B400284CBD /* CommentView.swift in Sources */,

--- a/IAteIt/IAteIt/Network/Utils/HttpMethod.swift
+++ b/IAteIt/IAteIt/Network/Utils/HttpMethod.swift
@@ -1,0 +1,12 @@
+//
+//  HttpHeader.swift
+//  IAteIt
+//
+//  Created by 박성수 on 1/29/24.
+//
+
+import Foundation
+
+enum HttpMethod: String {
+    case GET, POST, PUT, DELETE
+}

--- a/IAteIt/IAteIt/Network/Utils/JwtRequired.swift
+++ b/IAteIt/IAteIt/Network/Utils/JwtRequired.swift
@@ -1,0 +1,13 @@
+//
+//  JwtRequired.swift
+//  IAteIt
+//
+//  Created by 박성수 on 1/29/24.
+//
+
+import Foundation
+
+protocol JwtRequired {
+    var jwtToken: String { get set }
+    
+}

--- a/IAteIt/IAteIt/Network/Utils/Request.swift
+++ b/IAteIt/IAteIt/Network/Utils/Request.swift
@@ -1,0 +1,16 @@
+//
+//  Request.swift
+//  IAteIt
+//
+//  Created by 박성수 on 1/27/24.
+//
+
+import Foundation
+
+protocol Request {
+    associatedtype responseType: Response
+    
+    var method: HttpMethod { get set }
+    func urlRequest(url: URL) -> URLRequest
+}
+

--- a/IAteIt/IAteIt/Network/Utils/Response.swift
+++ b/IAteIt/IAteIt/Network/Utils/Response.swift
@@ -1,0 +1,18 @@
+//
+//  Response.swift
+//  IAteIt
+//
+//  Created by 박성수 on 1/27/24.
+//
+
+import Foundation
+
+protocol Response: Decodable {
+    associatedtype requestType: Request
+    
+    var status: Int { get set }
+    var code: String { get set }
+    var message: String { get set }
+    
+}
+


### PR DESCRIPTION

## 작업 내용
- request, response 에 요구되는 값들이 어느정도 정해져있어서 프로토콜을 추가했습니답
- associatedType 다른 프로젝트 하면서 배웠는데 확장성이 엄청있더라고요~~!

## 사용 예시

```
struct MemberResponse: Response {
    typealias requestType = MemberRequest
    
    var status: Int
    
    var code: String
    
    var message: String
    
}
```

```
// 토큰이 필요한 경우 JwtRequired 추가, 필요하지 않은 경우 빼면 됩니다
struct MemberRequest: Request, JwtRequired {
    typealias responseType = MemberResponse
    
    var method: HttpMethod
    
    func urlRequest(url: URL) -> URLRequest {
        <#code#>
    }
    
    var jwtToken: String
       
}
```
